### PR TITLE
fix: Calling `response.text()` after `response.json()` fails

### DIFF
--- a/packages/core/src/api/fetch.ts
+++ b/packages/core/src/api/fetch.ts
@@ -111,10 +111,9 @@ const sendRequest = async (opts: RequestOptions) => {
   if (!response.ok) {
     let errorMessage;
     try {
-      errorMessage = await response.json();
-    } catch (e) {
       errorMessage = await response.text();
-    }
+      errorMessage = JSON.parse(errorMessage);
+    } catch (e) {}
     if (errorMessage.errors) {
       errorMessage = errorMessage.errors.join(', ');
     } else if (typeof errorMessage !== 'string') {


### PR DESCRIPTION
The call to `.json()` accesses the response's body stream. At that
point, we cannot call another method to access the body stream because
it has already been consumed. The error message is:
```
'Response': body stream already read
```

The fix is to use `response.text()` and parse it as JSON. Or, we could
check the content-type and call the correct access method.