### PR TITLE
fix(auth): add missing query and hash after login redirect

### DIFF
--- a/packages/auth/src/HOCs.tsx
+++ b/packages/auth/src/HOCs.tsx
@@ -31,7 +31,10 @@ export const withAuth = <P extends any>(
 };
 
 const onRedirecting = (loginUrl: string) => {
-  window.localStorage.setItem(FRONTEGG_AFTER_AUTH_REDIRECT_URL, window.location.pathname);
+  window.localStorage.setItem(
+    FRONTEGG_AFTER_AUTH_REDIRECT_URL,
+    window.location.href.substring(window.location.origin.length)
+  );
   return <Redirect to={loginUrl} />;
 };
 


### PR DESCRIPTION
take the full path and substring it by the origin length

fixes #134