### PR TITLE
fix(auth): [FR-1080] fix social login wrapper

### DIFF
--- a/packages/auth/src/SocialLogins/SocialLogins.tsx
+++ b/packages/auth/src/SocialLogins/SocialLogins.tsx
@@ -33,7 +33,7 @@ export const SocialLogins: SocialLoginsWithCompoundComponents = (props: SocialLo
     return <Loader />;
   }
 
-  if (!socialLoginsConfig?.length) {
+  if (!socialLoginsConfig?.length || !socialLoginsConfig.some(({ active }) => active)) {
     return null;
   }
 


### PR DESCRIPTION
when all social login providers are empty, the OR should not appear