### PR TITLE
fix(audits): fix show filter icon if the filterable value is disabled

### DIFF
--- a/packages/audits/src/components/AuditsRawTable.tsx
+++ b/packages/audits/src/components/AuditsRawTable.tsx
@@ -26,16 +26,17 @@ export const AuditsRawTable: FC<IAuditsRawTable> = React.memo(({ headerProps, ..
           Header: header.displayName,
           sortable: header.sortable,
           Cell: getAuditsTableCells(header.name),
-          Filter: ({ value, setFilterValue, closePopup }) =>
-            header.filterable ? (
-              <Filter
-                name={header.displayName}
-                value={value}
-                setFilterValue={setFilterValue}
-                closePopup={closePopup}
-                type={header.type}
-              />
-            ) : null,
+          Filter: header.filterable
+            ? ({ value, setFilterValue, closePopup }) => (
+                <Filter
+                  name={header.displayName}
+                  value={value}
+                  setFilterValue={setFilterValue}
+                  closePopup={closePopup}
+                  type={header.type}
+                />
+              )
+            : undefined,
         })
       );
   }, [headerProps]);


### PR DESCRIPTION
Now the filter icon doesn't show if the filterable value is disabled.
![Снимок экрана 2021-02-02 в 12 54 44](https://user-images.githubusercontent.com/4667761/106590516-da0f6680-6555-11eb-95ba-8010896732f7.png)
