### PR TITLE
feat(auth): support render prop

### DIFF
--- a/packages/auth/src/AuthorizedContent/index.tsx
+++ b/packages/auth/src/AuthorizedContent/index.tsx
@@ -5,6 +5,7 @@ import { ContextHolder } from '@frontegg/rest-api';
 export interface AuthorizationProps {
   requiredRoles?: string[];
   requiredPermissions?: string[];
+  render?: (isAuthorized: boolean) => React.ReactNode | null;
 }
 
 const logger = Logger.from('AuthorizedContent');
@@ -40,5 +41,10 @@ export const AuthorizedContent: FC<AuthorizationProps> = (props) => {
       }
     }
   }
+
+  if (typeof props.render === 'function') {
+    return <>{props.render(isAuthorized)}</>;
+  }
+
   return isAuthorized ? <>{props.children}</> : null;
 };


### PR DESCRIPTION
There are many use cases where we want to render Component even if authorization fails 
(e.g render a disable action button if the user has no permissions etc..).
This commit adds the ability to pass render function to `AuthorizedContent` component which in
turn pass the `isAuthorized` value to the render function. This way the
user can decide how to render the component depends on the value of `isAuthorized`.