### PR TITLE
FR-1939: show audits in local timezone

### DIFF
--- a/packages/core/src/components/TableCells.tsx
+++ b/packages/core/src/components/TableCells.tsx
@@ -19,8 +19,8 @@ export const TableCells: TableCellsType = {
   DateAgo: ({ value }) => {
     return (
       <div className='fe-table-cell__date-ago'>
-        <div>{value ? moment(value).format('LLLL') : 'N/A'}</div>
-        {value && <div>{moment(value).fromNow()}</div>}
+        <div>{value ? moment.utc(value).local().format('LLLL') : 'N/A'}</div>
+        {value && <div>{moment.utc(value).local().fromNow()}</div>}
       </div>
     );
   },


### PR DESCRIPTION
fix
core
display audit created at in local time zone using moment library


https://user-images.githubusercontent.com/78534155/108623748-455ba280-7449-11eb-8aea-900c9a0377cb.mov


