### PR TITLE
remove the fitContent property

### DIFF
--- a/packages/connectivity/README.md
+++ b/packages/connectivity/README.md
@@ -65,7 +65,6 @@ Then add `ConnectivityPage` component to your route:
   - className - a className for the whole container
   - headClassName - a className for the header component
   - contentClassName - a className for the container of the table
-  - fitContent - the parameter makes a scrollable container for the table data
 
 ## Contributing
 

--- a/packages/connectivity/src/components/ConnectivityPage.tsx
+++ b/packages/connectivity/src/components/ConnectivityPage.tsx
@@ -12,14 +12,12 @@ export interface IConnectivityPage
   className?: string;
   headClassName?: string;
   contentClassName?: string;
-  fitContent?: boolean;
 }
 
 export const ConnectivityPage: FC<IConnectivityPage> = ({
   children,
   className,
   rootPath = defaultRootPath,
-  fitContent,
   headClassName,
   titleClassName,
   contentClassName,
@@ -35,11 +33,11 @@ export const ConnectivityPage: FC<IConnectivityPage> = ({
 
   return (
     <RootPathContext.Provider value={rootPath}>
-      <div className={classnames('fe-connectivity-page', className, fitContent && 'fe-connectivity-page-fit')}>
+      <div className={classnames('fe-connectivity-page', className)}>
         {children ?? (
           <>
-            <ConnectivityHeader className={headClassName} titleClassName={titleClassName} />
             <ConnectivityContent className={contentClassName} {...contentProps} />
+            <ConnectivityHeader className={headClassName} titleClassName={titleClassName} />
           </>
         )}
       </div>

--- a/packages/connectivity/src/styles/connectivity.scss
+++ b/packages/connectivity/src/styles/connectivity.scss
@@ -1,20 +1,3 @@
-// .fe-connectivity-page {
-//   height: 100%;
-//   overflow: auto;
-// }
-.fe-connectivity-page-fit {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  .fe-connectivity-context {
-    flex-grow: 1;
-    overflow: hidden;
-  }
-  .fe-connectivity-panel-shown,
-  .fe-connectivity-list {
-    height: 100%;
-  }
-}
 .fe-connectivity-context,
 .fe-connectivity-component {
   .fe-search {

--- a/packages/connectivity/src/styles/content.scss
+++ b/packages/connectivity/src/styles/content.scss
@@ -1,6 +1,14 @@
 .fe-connectivity {
+  &-page {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+  }
   &-context {
     padding: 2rem;
+    flex-grow: 1;
+    order: 1;
+    overflow: auto;
     .fe-connectivity-search {
       margin-bottom: 2rem;
     }


### PR DESCRIPTION
The `fitContent` property was removed. 
The scrolling of the container was fixed.

The video with a fixed height of the parent container:
https://user-images.githubusercontent.com/4667761/119617937-fe47c980-be0a-11eb-802f-9d8638342779.mov

The video with a free height of the parent container:
https://user-images.githubusercontent.com/4667761/119618018-161f4d80-be0b-11eb-8fc8-ced6ee3c6dbd.mov

FR-3005
