### PR TITLE
fix virtual scroll

### DIFF
--- a/packages/core/src/elements/Table/FeTableTBody.tsx
+++ b/packages/core/src/elements/Table/FeTableTBody.tsx
@@ -1,4 +1,4 @@
-import React, { FC, memo, useMemo, useRef } from 'react';
+import React, { FC, useMemo } from 'react';
 import classNames from 'classnames';
 import { Row, TableBodyPropGetter, TableBodyProps, UseExpandedRowProps } from 'react-table';
 import { FeTableExpandable } from './FeTableExpandable';
@@ -49,7 +49,6 @@ export const FeTableTBodyRow: FC<FeTableTBodyRowProps<any>> = (props: FeTableTBo
 
 export const FeTableTBody: FC<FeTableTBodyProps<any>> = <T extends object>(props: FeTableTBodyProps<T>) => {
   const { getTableBodyProps, prepareRow, rows, renderExpandedComponent, loading, pagination, onInfiniteScroll } = props;
-  const prevRowsLength = useRef(0);
   const { t } = useT();
 
   return (
@@ -65,9 +64,8 @@ export const FeTableTBody: FC<FeTableTBodyProps<any>> = <T extends object>(props
           {pagination === 'infinite-scroll' && index === Math.ceil(rows.length * 0.7) && (
             <Waypoint
               onEnter={() => {
-                if (!loading && rows.length !== prevRowsLength.current) {
+                if (!loading) {
                   onInfiniteScroll?.();
-                  prevRowsLength.current = rows.length;
                 }
               }}
             />

--- a/packages/elements-material-ui/src/Table/TableBody.tsx
+++ b/packages/elements-material-ui/src/Table/TableBody.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef } from 'react';
+import React, { FC } from 'react';
 import { makeStyles } from '@material-ui/core';
 import { useT, TableProps } from '@frontegg/react-core';
 import { TableBody as MTableBody, TableRow, TableCell } from '@material-ui/core';
@@ -36,7 +36,6 @@ const useRowStyles = makeStyles({
 });
 
 export const TableBody: FC<TableTBodyProps<any>> = <T extends object>(props: TableTBodyProps<T>) => {
-  const prevRowsLength = useRef(0);
   const {
     getTableBodyProps,
     prepareRow,
@@ -87,9 +86,8 @@ export const TableBody: FC<TableTBodyProps<any>> = <T extends object>(props: Tab
               {pagination === 'infinite-scroll' && index === Math.ceil(rows.length * 0.7) && (
                 <Waypoint
                   onEnter={() => {
-                    if (!loading && rows.length !== prevRowsLength.current) {
+                    if (!loading) {
                       onInfiniteScroll?.();
-                      prevRowsLength.current = rows.length;
                     }
                   }}
                 />


### PR DESCRIPTION
The problem was with the condition. If we do double sort without scroll -> it won't fetch more.

Right now, we don't have handling for the last fetch because we don't have **total** and **query** value for the next fetch. 
