### PR TITLE
Update Frontegg AdminPortal to 3.10.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "3.9.1",
+    "@frontegg/react-hooks": "3.10.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "3.9.0",
+    "@frontegg/react-hooks": "3.9.1",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "3.7.1",
+    "@frontegg/react-hooks": "3.7.2",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "3.7.2",
+    "@frontegg/react-hooks": "3.9.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,8 +12,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.9.0",
-    "@frontegg/react-hooks": "3.9.0",
+    "@frontegg/admin-portal": "3.9.1",
+    "@frontegg/react-hooks": "3.9.1",
     "react-router-dom": "5.x"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,8 +12,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.7.2",
-    "@frontegg/react-hooks": "3.7.2",
+    "@frontegg/admin-portal": "3.9.0",
+    "@frontegg/react-hooks": "3.9.0",
     "react-router-dom": "5.x"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,8 +12,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.9.1",
-    "@frontegg/react-hooks": "3.9.1",
+    "@frontegg/admin-portal": "3.10.0",
+    "@frontegg/react-hooks": "3.10.0",
     "react-router-dom": "5.x"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -12,8 +12,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.7.1",
-    "@frontegg/react-hooks": "3.7.1",
+    "@frontegg/admin-portal": "3.7.2",
+    "@frontegg/react-hooks": "3.7.2",
     "react-router-dom": "5.x"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2987,10 +2987,10 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@3.7.1":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.7.1.tgz#07802bd318eed4b406dcc82c4a43533001ae0cdf"
-  integrity sha512-OkUrXvtXPeA5hceUkBpHzuXdhipmPrMdbr40jLyryswECxsWGfzDlaeU3+CqeVQhp1AVjGuyWFLXET2qsd3Yzw==
+"@frontegg/admin-portal@3.7.2":
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.7.2.tgz#acaabf4ffa867a8b8e65d003b2bc228626a65ef5"
+  integrity sha512-x9csdR/ikuKvpuekuUFu2eAgS1IBrc5lJf2o/8YqZuOvSmLgIgeDdMl+5/MlPtPa4u9iqCmoU++hqxatikTY7w==
   dependencies:
     "@frontegg/injector" "0.0.26"
     uuid "^8.3.0"
@@ -3000,18 +3000,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/injector/-/injector-0.0.26.tgz#771c96da1f930d732d5d286ed1067697c7e239eb"
   integrity sha512-Y0a2QKihNi7l4jdT5mez7ecIEZCaKW5ga+RzpD5JvrpX5N6ZM7bsSCaKoyAXJgMdU1mWy/2ZNjp9vY8Z2OQdKA==
 
-"@frontegg/react-hooks@3.7.1":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-3.7.1.tgz#9ec8cdae8a24f9d012f54da8698e21bbcb0e5709"
-  integrity sha512-s5hL3laVGYmcHEAZ9a1vMSCG1NhsNqiv+0ErfAyq6AeBc/KU7Y5LPPWEYBvbcfd70PBxbCQY7Taw7kdP2xsVaw==
+"@frontegg/react-hooks@3.7.2":
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-3.7.2.tgz#167849edeef3712fb86147bbcf60f88411f6ffef"
+  integrity sha512-LnhSAq0tHLiAh8jYYJqHR5uRhc02MeD46pkWO2x1/pOhubFzwYX2n2fXDzgTXwMfskaUKMDbVGpxS1WmG+6HWw==
   dependencies:
-    "@frontegg/redux-store" "3.7.1"
+    "@frontegg/redux-store" "3.7.2"
     react-redux "^7.x"
 
-"@frontegg/redux-store@3.7.1":
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.7.1.tgz#73ecbc757c3dc83dc32bd8e4b99ee052d4d61acf"
-  integrity sha512-CadGtwdJmnR5Omxvtk6Txi47DgyXNB90z2GB+mlLs7KLgymTwthIBSK97xETdFzng4+ZYvHjqeudrxzzolyyLA==
+"@frontegg/redux-store@3.7.2":
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.7.2.tgz#5bad9188fd9af7734b6ff108e83c3ec50a7486ba"
+  integrity sha512-qyWK9u726TC6hygNg6mtEwGls9hCF0VoTcyEJ8fUZMDfayounpLOJRBCJZxH0l38wCHleDSs1xxOLBoLy214Rg==
   dependencies:
     "@frontegg/rest-api" "^2.10.9"
     "@reduxjs/toolkit" "^1.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2987,10 +2987,10 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@3.7.2":
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.7.2.tgz#acaabf4ffa867a8b8e65d003b2bc228626a65ef5"
-  integrity sha512-x9csdR/ikuKvpuekuUFu2eAgS1IBrc5lJf2o/8YqZuOvSmLgIgeDdMl+5/MlPtPa4u9iqCmoU++hqxatikTY7w==
+"@frontegg/admin-portal@3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.9.0.tgz#d01beeb7b403821b6130d087e5b7249e56417cbc"
+  integrity sha512-1s7Me0Hp8BeAt0NXr8XzKXMRZZ2dr0NxhR81nAr9xzjMcLpXFfvJFM/peqqNvxXV0Xed8wiSRtVE6Fcm6rJSUA==
   dependencies:
     "@frontegg/injector" "0.0.26"
     uuid "^8.3.0"
@@ -3000,18 +3000,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/injector/-/injector-0.0.26.tgz#771c96da1f930d732d5d286ed1067697c7e239eb"
   integrity sha512-Y0a2QKihNi7l4jdT5mez7ecIEZCaKW5ga+RzpD5JvrpX5N6ZM7bsSCaKoyAXJgMdU1mWy/2ZNjp9vY8Z2OQdKA==
 
-"@frontegg/react-hooks@3.7.2":
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-3.7.2.tgz#167849edeef3712fb86147bbcf60f88411f6ffef"
-  integrity sha512-LnhSAq0tHLiAh8jYYJqHR5uRhc02MeD46pkWO2x1/pOhubFzwYX2n2fXDzgTXwMfskaUKMDbVGpxS1WmG+6HWw==
+"@frontegg/react-hooks@3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-3.9.0.tgz#dc7c20900b220f7e020a7eb543e0536c952d4bee"
+  integrity sha512-Ijst5VsNd+GqL26NwuhLw1W6z+h3xUuNkf1ij0B/ctncMPd/rOgBneloCZwmmviZe3wl+RSohmik2dPxB46Efg==
   dependencies:
-    "@frontegg/redux-store" "3.7.2"
+    "@frontegg/redux-store" "3.9.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@3.7.2":
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.7.2.tgz#5bad9188fd9af7734b6ff108e83c3ec50a7486ba"
-  integrity sha512-qyWK9u726TC6hygNg6mtEwGls9hCF0VoTcyEJ8fUZMDfayounpLOJRBCJZxH0l38wCHleDSs1xxOLBoLy214Rg==
+"@frontegg/redux-store@3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.9.0.tgz#9083479b608374497349adfcd48f8f3d4c9a779e"
+  integrity sha512-6NxrgASnzn8W+qF8/9USXOIz74Hv/QkZGZgi9QGtAZaJgvWvACFrt+3vBiACnMlU3JpCG+bkOM+ukLBZFKB4sQ==
   dependencies:
     "@frontegg/rest-api" "^2.10.9"
     "@reduxjs/toolkit" "^1.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2987,10 +2987,10 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@3.9.1":
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.9.1.tgz#f6365fc2122fa588c8a7cbe02ca7c59f4250f432"
-  integrity sha512-wCil9rv0dtrTVCu076N4htvfct5nNA9J7i7zl/16xK2vFAyDhfapYt4g2h1SAX/R65LUxBdOJdZRRoEL/mIfZA==
+"@frontegg/admin-portal@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.10.0.tgz#a0937fc637b8f7df30ff0654a218da4674997be9"
+  integrity sha512-oqmaAWHCM2S4EZWK6ziEq5gbE7L8M6bXBL75G70RKhExiZFuFG8iYEI3H71uf4aM7AQvyZcY8Pwmu8hLMOpyRg==
   dependencies:
     "@frontegg/injector" "0.0.26"
     uuid "^8.3.0"
@@ -3000,18 +3000,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/injector/-/injector-0.0.26.tgz#771c96da1f930d732d5d286ed1067697c7e239eb"
   integrity sha512-Y0a2QKihNi7l4jdT5mez7ecIEZCaKW5ga+RzpD5JvrpX5N6ZM7bsSCaKoyAXJgMdU1mWy/2ZNjp9vY8Z2OQdKA==
 
-"@frontegg/react-hooks@3.9.1":
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-3.9.1.tgz#d9c35ee9294c07cf21751b6dd186c6e5b5438db1"
-  integrity sha512-U3cIygNIyYXae5GBnJvrmL47t6j1wf7AlCe8TZaAYMJO4ploZJF8eMexyiGRmXLe2N74NTpuabk7ftpjyyjAdA==
+"@frontegg/react-hooks@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-3.10.0.tgz#1dc1e9df14b90f8da47a75c8ee1b4c8d41192a64"
+  integrity sha512-kyTR+5vaK4tJ31PA8823JukmFr5NwtHgAfmrUVdaC3cTj4prrc2KRZbvUsweLNuAE4y2xlO4oxycj/sThVvn7g==
   dependencies:
-    "@frontegg/redux-store" "3.9.1"
+    "@frontegg/redux-store" "3.10.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@3.9.1":
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.9.1.tgz#4d2261155a26d80de229badc5e05b9697b6b4bfc"
-  integrity sha512-ING8o/w7NVpfKgfrNA/ACF2nwKVWkb/tGZwct2Nw/cNvjowdSwUT5BaB/kOPcneQqtgw8SF7mccz9KsLMxyelg==
+"@frontegg/redux-store@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.10.0.tgz#7574bd3bae0a85ba01f133d86a9b23548f0ff12f"
+  integrity sha512-KhyIGmuzn0GWYj9XOMCojjh8Bn3FVe1xZpp7/+byy+RkQ0MWKDrDREnMfj2mg4C++hqsmSqXbh3mQY7LSSIUmg==
   dependencies:
     "@frontegg/rest-api" "^2.10.9"
     "@reduxjs/toolkit" "^1.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2987,10 +2987,10 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@3.9.0":
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.9.0.tgz#d01beeb7b403821b6130d087e5b7249e56417cbc"
-  integrity sha512-1s7Me0Hp8BeAt0NXr8XzKXMRZZ2dr0NxhR81nAr9xzjMcLpXFfvJFM/peqqNvxXV0Xed8wiSRtVE6Fcm6rJSUA==
+"@frontegg/admin-portal@3.9.1":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.9.1.tgz#f6365fc2122fa588c8a7cbe02ca7c59f4250f432"
+  integrity sha512-wCil9rv0dtrTVCu076N4htvfct5nNA9J7i7zl/16xK2vFAyDhfapYt4g2h1SAX/R65LUxBdOJdZRRoEL/mIfZA==
   dependencies:
     "@frontegg/injector" "0.0.26"
     uuid "^8.3.0"
@@ -3000,18 +3000,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/injector/-/injector-0.0.26.tgz#771c96da1f930d732d5d286ed1067697c7e239eb"
   integrity sha512-Y0a2QKihNi7l4jdT5mez7ecIEZCaKW5ga+RzpD5JvrpX5N6ZM7bsSCaKoyAXJgMdU1mWy/2ZNjp9vY8Z2OQdKA==
 
-"@frontegg/react-hooks@3.9.0":
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-3.9.0.tgz#dc7c20900b220f7e020a7eb543e0536c952d4bee"
-  integrity sha512-Ijst5VsNd+GqL26NwuhLw1W6z+h3xUuNkf1ij0B/ctncMPd/rOgBneloCZwmmviZe3wl+RSohmik2dPxB46Efg==
+"@frontegg/react-hooks@3.9.1":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-3.9.1.tgz#d9c35ee9294c07cf21751b6dd186c6e5b5438db1"
+  integrity sha512-U3cIygNIyYXae5GBnJvrmL47t6j1wf7AlCe8TZaAYMJO4ploZJF8eMexyiGRmXLe2N74NTpuabk7ftpjyyjAdA==
   dependencies:
-    "@frontegg/redux-store" "3.9.0"
+    "@frontegg/redux-store" "3.9.1"
     react-redux "^7.x"
 
-"@frontegg/redux-store@3.9.0":
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.9.0.tgz#9083479b608374497349adfcd48f8f3d4c9a779e"
-  integrity sha512-6NxrgASnzn8W+qF8/9USXOIz74Hv/QkZGZgi9QGtAZaJgvWvACFrt+3vBiACnMlU3JpCG+bkOM+ukLBZFKB4sQ==
+"@frontegg/redux-store@3.9.1":
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.9.1.tgz#4d2261155a26d80de229badc5e05b9697b6b4bfc"
+  integrity sha512-ING8o/w7NVpfKgfrNA/ACF2nwKVWkb/tGZwct2Nw/cNvjowdSwUT5BaB/kOPcneQqtgw8SF7mccz9KsLMxyelg==
   dependencies:
     "@frontegg/rest-api" "^2.10.9"
     "@reduxjs/toolkit" "^1.5.0"


### PR DESCRIPTION
### AdminPortal 3.10.0:
- FR-3140 - Fix 'replace' module if exists
- FR-3140 - Remove package json module key for Frontegg libraries
- FR-2475 - add custom login footer

### AdminPortal 3.9.1:
- hide subscription tab