### PR TITLE
Update Frontegg AdminPortal to 3.14.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "3.14.0",
+    "@frontegg/react-hooks": "3.14.1",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.14.0",
-    "@frontegg/react-hooks": "3.14.0"
+    "@frontegg/admin-portal": "3.14.1",
+    "@frontegg/react-hooks": "3.14.1"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.14.0",
-    "@frontegg/react-hooks": "3.14.0",
+    "@frontegg/admin-portal": "3.14.1",
+    "@frontegg/react-hooks": "3.14.1",
     "react-router-dom": "5.x"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3010,10 +3010,10 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@3.14.0":
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.14.0.tgz#391508227cefeeaf1e4d03541a47af06e64eefd3"
-  integrity sha512-V6wLVoJWcaskniPD5GXmaTf6du/cm2xwcUJ4si5kOOHnpFg9SI8I3gnOzhmQ2zwpZZyfYKcBu5FXQoZaZ8K3+Q==
+"@frontegg/admin-portal@3.14.1":
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.14.1.tgz#01c7a579bca0eee9d8cae4ed0903c73bb2499f94"
+  integrity sha512-atz7kvFovhgKSXatGfvNXUFe4i0+/hTwNNe5l2mWtz1OX/NQJDZRg32oseGnZMVzYeNcpmGQnUoLI7Dz/xZzqQ==
   dependencies:
     "@frontegg/injector" "0.0.26"
     uuid "^8.3.0"
@@ -3023,18 +3023,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/injector/-/injector-0.0.26.tgz#771c96da1f930d732d5d286ed1067697c7e239eb"
   integrity sha512-Y0a2QKihNi7l4jdT5mez7ecIEZCaKW5ga+RzpD5JvrpX5N6ZM7bsSCaKoyAXJgMdU1mWy/2ZNjp9vY8Z2OQdKA==
 
-"@frontegg/react-hooks@3.14.0":
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-3.14.0.tgz#969e961271c440ab93b4a95a17283def94556329"
-  integrity sha512-c4ip3KRcNu06VXqNPp53IY5Xs4Ae//UTGKQNYOZC0/TQ++njBOQTpvnu9cIOD5ne21oifcOUxn5o4lBAr9/5kA==
+"@frontegg/react-hooks@3.14.1":
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-3.14.1.tgz#ab94d2d1d6b553cea8f530cdbb356447929bfa2b"
+  integrity sha512-URVV+HCr56z/le07XFhsbyriNq6fZaQbimyBQbG76gCgyUjnML/Csi4tlUCQygankpt/JtxPs698P/7rd/nV1A==
   dependencies:
-    "@frontegg/redux-store" "3.14.0"
+    "@frontegg/redux-store" "3.14.1"
     react-redux "^7.x"
 
-"@frontegg/redux-store@3.14.0":
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.14.0.tgz#517fed212824b00416dcffdde6d836e59b5cf809"
-  integrity sha512-C6CCCbtO0Mv6fxj7k4Mj3gt8YCwajl5BHSslqfXaVM3w8OueOG8/D3D3jS6A67ZHPPji9Z1YCkfghRFZJXv8Rw==
+"@frontegg/redux-store@3.14.1":
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.14.1.tgz#ed7698c6b708ead78295eff0ec33f8a9f6b2fa0c"
+  integrity sha512-eYT9NK8ehxEDfHnzbunUUj4xROTu4Yxcx3d7Sg+Y1z7mBwxiTRTzjb9WCe1ZQTZMEuVGQiOKg9ACcwh5mpSk/g==
   dependencies:
     "@frontegg/rest-api" "^2.10.15"
     "@reduxjs/toolkit" "^1.5.0"


### PR DESCRIPTION
### AdminPortal 3.14.1:
- v3.14.1
- FR-3944 - Added custom loader as an option to refetch request authorize
- FR-3981 - when choose other  saml vendor then reset saml config to manual
- id for admin box x
- FR-3889 - support permissions in admin box
- FR-3793 - add login box customizion
- FR-3596 - custom social login icon