### PR TITLE
Update Frontegg AdminPortal to 3.15.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "3.14.1",
+    "@frontegg/react-hooks": "3.15.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.14.1",
-    "@frontegg/react-hooks": "3.14.1"
+    "@frontegg/admin-portal": "3.15.0",
+    "@frontegg/react-hooks": "3.15.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "3.14.1",
-    "@frontegg/react-hooks": "3.14.1",
+    "@frontegg/admin-portal": "3.15.0",
+    "@frontegg/react-hooks": "3.15.0",
     "react-router-dom": "5.x"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3010,10 +3010,10 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@3.14.1":
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.14.1.tgz#01c7a579bca0eee9d8cae4ed0903c73bb2499f94"
-  integrity sha512-atz7kvFovhgKSXatGfvNXUFe4i0+/hTwNNe5l2mWtz1OX/NQJDZRg32oseGnZMVzYeNcpmGQnUoLI7Dz/xZzqQ==
+"@frontegg/admin-portal@3.15.0":
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-3.15.0.tgz#a8a133a7132853cfda4b32c85ce3a00120fb217b"
+  integrity sha512-jd32RFn+KmcCVXalAZSkEULAvM4cUlUsAX4Iv7rgtv5bcm/EbXa5BK+kSwM7MM3ZMWTKtVTFNkrNzPB6+kf1dQ==
   dependencies:
     "@frontegg/injector" "0.0.26"
     uuid "^8.3.0"
@@ -3023,18 +3023,18 @@
   resolved "https://registry.yarnpkg.com/@frontegg/injector/-/injector-0.0.26.tgz#771c96da1f930d732d5d286ed1067697c7e239eb"
   integrity sha512-Y0a2QKihNi7l4jdT5mez7ecIEZCaKW5ga+RzpD5JvrpX5N6ZM7bsSCaKoyAXJgMdU1mWy/2ZNjp9vY8Z2OQdKA==
 
-"@frontegg/react-hooks@3.14.1":
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-3.14.1.tgz#ab94d2d1d6b553cea8f530cdbb356447929bfa2b"
-  integrity sha512-URVV+HCr56z/le07XFhsbyriNq6fZaQbimyBQbG76gCgyUjnML/Csi4tlUCQygankpt/JtxPs698P/7rd/nV1A==
+"@frontegg/react-hooks@3.15.0":
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-3.15.0.tgz#d86154f49378e7429439100d5361be0aedb17936"
+  integrity sha512-jzbvs/eNyKxqJzBVayPZiG8u1DAmqw0yVXN4EFl3uGzw8y9m/g7c7zXz+gvsexikX+h7VQgePYEIGXC6AyvIeg==
   dependencies:
-    "@frontegg/redux-store" "3.14.1"
+    "@frontegg/redux-store" "3.15.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@3.14.1":
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.14.1.tgz#ed7698c6b708ead78295eff0ec33f8a9f6b2fa0c"
-  integrity sha512-eYT9NK8ehxEDfHnzbunUUj4xROTu4Yxcx3d7Sg+Y1z7mBwxiTRTzjb9WCe1ZQTZMEuVGQiOKg9ACcwh5mpSk/g==
+"@frontegg/redux-store@3.15.0":
+  version "3.15.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-3.15.0.tgz#7a3d0c0cf65ca267204f1f5a77aaf3a01f754bb7"
+  integrity sha512-c4t3lHJGDqUe6a4jZlcjFROdkSXpw2OkPdL2iCfZajKW2wt3qVInSYNRp/3OXBL9FmNgdjAVzGhivlDP9DADCw==
   dependencies:
     "@frontegg/rest-api" "^2.10.15"
     "@reduxjs/toolkit" "^1.5.0"


### PR DESCRIPTION
### AdminPortal 3.15.0:
- v3.15.0
- FR-3814 - fix configuration
- FR-3944 - remove logs and added custom loader to a condition in injector
- FR-3987 - fix social layout