### PR TITLE
Update Frontegg AdminPortal to 4.10.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "4.9.0",
+    "@frontegg/react-hooks": "4.10.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.9.0",
-    "@frontegg/react-hooks": "4.9.0"
+    "@frontegg/admin-portal": "4.10.0",
+    "@frontegg/react-hooks": "4.10.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.9.0",
-    "@frontegg/react-hooks": "4.9.0",
+    "@frontegg/admin-portal": "4.10.0",
+    "@frontegg/react-hooks": "4.10.0",
     "react-router-dom": ">5.0.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,44 +2998,44 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.9.0.tgz#96a2bb4141a424a743997cb5f0db94b6485d917a"
-  integrity sha512-jWG3ixK7LQk99NYdF24SZjWCDesY+KpHfHcvDkGwM+8HpiBFI3eSVyJYDc5BsLv2QbBa4aDDs38nrqTRlmmeEA==
+"@frontegg/admin-portal@4.10.0":
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.10.0.tgz#c5c19a599b6c13adaef19303c5566794f33c99c7"
+  integrity sha512-vaLIHI2v45JBCzwlIC/sJuJLvDpPeyz0WK2zrkZwJ+yGXIHziSUI5Lxjhhsqmp2Kkrnap8Rsoh37czo9nDE+NA==
   dependencies:
-    "@frontegg/redux-store" "4.9.0"
-    "@frontegg/types" "4.9.0"
+    "@frontegg/redux-store" "4.10.0"
+    "@frontegg/types" "4.10.0"
 
-"@frontegg/react-hooks@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.9.0.tgz#cc533dc399adbeeb8c000a809f7ebff2a1ab081e"
-  integrity sha512-bbAtL0KzqjoO9ZRYJOd9kLAUUzteLA0r7fN0zfE7LQ0a/Fi+f7OjWuOgsUVgWcXKArq4iCN5Yuz5oKw/tUX82A==
+"@frontegg/react-hooks@4.10.0":
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.10.0.tgz#df80724dfe2ac3388f27c615364fcb3d52b5a48e"
+  integrity sha512-DpkBZjUGePhntglZdiG1ewcCrvePpzEuECjpt1DaxR9YWQRPfff4imV0Q+DevwMrFY0RurCHkQMuo87zJpCONw==
   dependencies:
-    "@frontegg/redux-store" "4.9.0"
+    "@frontegg/redux-store" "4.10.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.9.0.tgz#4185a83ec4c54417c6973a323c02baac5a031efc"
-  integrity sha512-dFgYQFA+ykGE9lN/eJn94kpL6+PKsa6z0NxSp2TF6fKkZu+YzUTfEluF3sMnu3KO5i1qH6TX6pF+Im73OCJtbg==
+"@frontegg/redux-store@4.10.0":
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.10.0.tgz#3e139719b582bd3fc6557bbbd2af81bc762bab67"
+  integrity sha512-c782FPL9tG151EhUyPixjGtbba+8EOriYAW7xDjVAEN4pQpyWeMubO7XpKeNHZMr2DuKY869BQnKzIrSiiwZBA==
   dependencies:
-    "@frontegg/rest-api" "^2.10.19"
+    "@frontegg/rest-api" "^2.10.21"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
     tslib "^2.1.0"
     uuid "^8.3.0"
 
-"@frontegg/rest-api@^2.10.19":
-  version "2.10.19"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.19.tgz#7adba708414ff9210bdb215c2e2594cec4399ab9"
-  integrity sha512-HorhSDROvDC/18RKiDcNXn8XbbMJQswOVXMXe2Y8eLZ2TEJVooq0luXonsqogArRUyPu0U6nhyYl2s+lexi4JA==
+"@frontegg/rest-api@^2.10.21":
+  version "2.10.21"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.21.tgz#098c6e0f2c16b447e07f75941c5edaa47ff60978"
+  integrity sha512-UrJr12RwW9S/ezjRLZ2luVcY5YPT6+jck4qpHKuTsANpQctMT2N5BPm18mEp+t5aHm7jqFPgiA17XC1vnvZVDw==
   dependencies:
     tslib "^2.3.0"
 
-"@frontegg/types@4.9.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.9.0.tgz#114847fae6ae20497a2d1682ce20609f770d9cd7"
-  integrity sha512-zflAXjwdi163HDPYPF5S5XeXEqxv4yJrIk2OVaFT3j+h38J3mlquPxyeM96V1pb3IcZeUzWs8cJBSJfpM+m+aA==
+"@frontegg/types@4.10.0":
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.10.0.tgz#72c05f11d59cf6cf1577a6801760f5f447ce5ece"
+  integrity sha512-G2O7leI+tS1pBXxlHfiRQd+oRShmB2zLMCF7zl07ava8wp9aYFDMOqJmiNEMSGeFfO3gHu7AdTgGMBS1pxUe0w==
   dependencies:
     csstype "^3.0.8"
 


### PR DESCRIPTION
### AdminPortal 4.10.0:
- [FR-4154](https://frontegg.atlassian.net/browse/FR-4154) - support invitation token on signup - [ce6f59ed](https://github.com/frontegg/admin-box/pulls?q=ce6f59ed)
- [FR-4151](https://frontegg.atlassian.net/browse/FR-4151) - otc flow - [8ac73190](https://github.com/frontegg/admin-box/pulls?q=8ac73190)
- [FR-3926](https://frontegg.atlassian.net/browse/FR-3926) - Create new saga middleware foreach store - [de4f5b28](https://github.com/frontegg/admin-box/pulls?q=de4f5b28)