### PR TITLE
Update Frontegg AdminPortal to 4.12.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "4.11.0",
+    "@frontegg/react-hooks": "4.12.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.11.0",
-    "@frontegg/react-hooks": "4.11.0"
+    "@frontegg/admin-portal": "4.12.0",
+    "@frontegg/react-hooks": "4.12.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.11.0",
-    "@frontegg/react-hooks": "4.11.0",
+    "@frontegg/admin-portal": "4.12.0",
+    "@frontegg/react-hooks": "4.12.0",
     "react-router-dom": ">5.0.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,26 +2998,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.11.0.tgz#77c67b8f0ef9f03d489b0530637b6d1274a5e163"
-  integrity sha512-FZslWbygkwVSVtUoGl4YwD5mlT6JjfOaG1AdbB7R1AiFVndT+XZK8/Kc0GvTIoVGOiEk6jYc9YJeMgMvcyVoCQ==
+"@frontegg/admin-portal@4.12.0":
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.12.0.tgz#776d496f4b8b728f814205449c47a2e601e16174"
+  integrity sha512-K5dJt6JfV6A6Me/dQsSbeMfxL7kK+vBFiTXFDVwF8yvnQDFJwgZPpfivRK4HRstlZ3C1MlzlGSNp0gGRvnwGlw==
   dependencies:
-    "@frontegg/redux-store" "4.11.0"
-    "@frontegg/types" "4.11.0"
+    "@frontegg/redux-store" "4.12.0"
+    "@frontegg/types" "4.12.0"
 
-"@frontegg/react-hooks@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.11.0.tgz#ba97661bec64292fe8b5ca9d9ca4504c30be3d9a"
-  integrity sha512-zh2wxD0veX/wg6r+ssFmm/LIE2JepYECn+Ffr/U7mkJ6b6L/N8WiNAcMQDpVSXuxWSYPtuIHdvOJ4CBRDtwBGg==
+"@frontegg/react-hooks@4.12.0":
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.12.0.tgz#334316319fd62f8a76c39d7a1ddba0c7faeea082"
+  integrity sha512-otuNOG1n2M1/nKUq7Db9PcTWYTz3XhjpT+5jGhXyo9aLlDbaCYCWKJmfPUNvkYlDP+5sAN9CB29PJBmcY19gfg==
   dependencies:
-    "@frontegg/redux-store" "4.11.0"
+    "@frontegg/redux-store" "4.12.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.11.0.tgz#b2fc387765a349eb02932d8e5c94d1788455543c"
-  integrity sha512-+8GSxne+P5j5jY4aat/CQy0j4VXElqUghE8HVB7IDRYKQMrqlZCUDM9VBo+Ly/0RAZmP5LHENtBoKEPzlFhjaQ==
+"@frontegg/redux-store@4.12.0":
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.12.0.tgz#e5481e4f39718b3ba4ab527369012c519dd33e55"
+  integrity sha512-7lhdm73x3sH+xH/9ww+472XfDB3ThB9+MYFvDvpTVTVmRmK6UvsuzLF9szdB9fqsnXWy7v0IPSI9V3tpoZFBGw==
   dependencies:
     "@frontegg/rest-api" "^2.10.21"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3032,10 +3032,10 @@
   dependencies:
     tslib "^2.3.0"
 
-"@frontegg/types@4.11.0":
-  version "4.11.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.11.0.tgz#48825c1f5bdcc8bb230393c89b2a231be908413b"
-  integrity sha512-9ZKLRnGVkp7cxXIw7kVX/6gNt+ZH3Nwj7JO+7pHGEe+M6oIqP159qss66K+xCMVXZbJOZkoFhR4ON9+aJEVpIg==
+"@frontegg/types@4.12.0":
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.12.0.tgz#67d377a5a426401d412824228464b49f9508063e"
+  integrity sha512-MmkcGhE6CHH3uN4DcFpm//1PmTULii8UNFSJ18uX6uPHAMDK2XXDF7tg5fAVN/uir6dbw85nWpvfIrM5CXxoFA==
   dependencies:
     csstype "^3.0.8"
 


### PR DESCRIPTION
### AdminPortal 4.12.0:
- [FR-3926](https://frontegg.atlassian.net/browse/FR-3926) - rename data-testid to data-test-id - [0fca4341](https://github.com/frontegg/admin-box/pulls?q=0fca4341)
- [FR-3965](https://frontegg.atlassian.net/browse/FR-3965) - magic link prelogin page header - [5d2a499f](https://github.com/frontegg/admin-box/pulls?q=5d2a499f)