### PR TITLE
Update Frontegg AdminPortal to 4.17.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "4.16.1",
+    "@frontegg/react-hooks": "4.17.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.16.1",
-    "@frontegg/react-hooks": "4.16.1"
+    "@frontegg/admin-portal": "4.17.0",
+    "@frontegg/react-hooks": "4.17.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.16.1",
-    "@frontegg/react-hooks": "4.16.1",
+    "@frontegg/admin-portal": "4.17.0",
+    "@frontegg/react-hooks": "4.17.0",
     "react-router-dom": ">5.0.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,44 +2998,44 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@4.16.1":
-  version "4.16.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.16.1.tgz#4a8219b34285cc8bc0f8328dc45bbc6be6cf78aa"
-  integrity sha512-hI6edzPUwaBqMBrQHi8X1hfafJbBunGheNStJA3kJe1dyJUUmFN4rw6vV9PGS+5afSOWECiG/EPLq8zRNnol9w==
+"@frontegg/admin-portal@4.17.0":
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.17.0.tgz#b2ce1e2864c9f596424ec4e899b933f95b888ec9"
+  integrity sha512-YG+R0oIurRKVsn6xoWjNVFD25g+ZHwLLDKpD6HG4mbci85Dg+Wk9Mv3g3Q5LEwTIcES5rozyqSjllymjdmgR0Q==
   dependencies:
-    "@frontegg/redux-store" "4.16.1"
-    "@frontegg/types" "4.16.1"
+    "@frontegg/redux-store" "4.17.0"
+    "@frontegg/types" "4.17.0"
 
-"@frontegg/react-hooks@4.16.1":
-  version "4.16.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.16.1.tgz#57061e18bfa8d6c30c50f1031a27bf3426a81ff8"
-  integrity sha512-CaJtkApuKh/C3SLFkTOxmWPexfKuN7y0SBQnnPOafiv8/Tcwfx1CRKznEgGay8r6jyKntQK2KYdiZ6FChvAFJg==
+"@frontegg/react-hooks@4.17.0":
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.17.0.tgz#4ed7da2d367826c1ecba9f770fee87e770ea9375"
+  integrity sha512-rRWs7eC0KxNyD7BsvkK/ung3ngzNjVrzKLtR8UKMolB2bM3k0QYJ4vV8QFWsI1JmyeXEK37tmb+49p0JM0fUVw==
   dependencies:
-    "@frontegg/redux-store" "4.16.1"
+    "@frontegg/redux-store" "4.17.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@4.16.1":
-  version "4.16.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.16.1.tgz#1a214dc9b4cf6823bcf8e9bbbc37dc8a1e0b5144"
-  integrity sha512-zFWqAJMYOkVUz92QaaRiCX37+HGT/q3OKKPnxA0RrNy42ia3QwuMyWgEa1YmDNYEwITcE+cM9/DYXIiMtaxhmg==
+"@frontegg/redux-store@4.17.0":
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.17.0.tgz#23ea5560ed0fa256b7d43153ae836e173031c407"
+  integrity sha512-GHNuih8khj5DqydUOdJUxmEOHqAqQyYkzuzvOeyVbUrt2UFoecJiobvX9sF1yQ+NVuXl6wLZ3nR7WRrz+5rxrA==
   dependencies:
-    "@frontegg/rest-api" "^2.10.21"
+    "@frontegg/rest-api" "^2.10.22"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
     tslib "^2.1.0"
     uuid "^8.3.0"
 
-"@frontegg/rest-api@^2.10.21":
-  version "2.10.21"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.21.tgz#098c6e0f2c16b447e07f75941c5edaa47ff60978"
-  integrity sha512-UrJr12RwW9S/ezjRLZ2luVcY5YPT6+jck4qpHKuTsANpQctMT2N5BPm18mEp+t5aHm7jqFPgiA17XC1vnvZVDw==
+"@frontegg/rest-api@^2.10.22":
+  version "2.10.25"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.25.tgz#cbd7611d7f9cc61ea74d806ccbf7d36376ba1c9a"
+  integrity sha512-Lbb8YD1W0ocgECacvzonzioJC6LqTW3HLCzkGbdUxyNEqtdfDrfEgWa/tx1+pwDFDq9/lrYYSYqWvyKtVqIfCg==
   dependencies:
     tslib "^2.3.0"
 
-"@frontegg/types@4.16.1":
-  version "4.16.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.16.1.tgz#f7728c46808cccfb68d9da238fca2b60ea84afb6"
-  integrity sha512-VbvjiSrPZL17R0zR/S/K5em5KoA4jAwM18Gy3CAL+ncJIvw9UMdQnmZvKkcKxfFCPKbfI4KrlxAUbq69vXcK3A==
+"@frontegg/types@4.17.0":
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.17.0.tgz#22942ae393eaae23307f2ce207a0638ed10ce16c"
+  integrity sha512-jGufdN1QfqusSqU1ZyGdHFRhMsSX7Ru0PaD//qOAiA4cGEurLUGtyLFpI6raxYpAM4zw9cy/GuIW2t7OqZhALw==
   dependencies:
     csstype "^3.0.8"
 


### PR DESCRIPTION
### AdminPortal 4.17.0:
- [FR-4187](https://frontegg.atlassian.net/browse/FR-4187) - add payment method update, some refactor - [d3f1e699](https://github.com/frontegg/admin-box/pulls?q=d3f1e699)
- [FR-4220](https://frontegg.atlassian.net/browse/FR-4220) - Login box bugs fixes - [8951df17](https://github.com/frontegg/admin-box/pulls?q=8951df17)
- [FR-4201](https://frontegg.atlassian.net/browse/FR-4201) - inner provider work with relative key - [f43da38b](https://github.com/frontegg/admin-box/pulls?q=f43da38b)
- [FR-3906](https://frontegg.atlassian.net/browse/FR-3906) - Subscription Split Checkout component - [00b8a434](https://github.com/frontegg/admin-box/pulls?q=00b8a434)
- [FR-4192](https://frontegg.atlassian.net/browse/FR-4192) - revert  magic link text - [135c64cf](https://github.com/frontegg/admin-box/pulls?q=135c64cf)
- [FR-4192](https://frontegg.atlassian.net/browse/FR-4192) - Magic link text - [ac9a4a3b](https://github.com/frontegg/admin-box/pulls?q=ac9a4a3b)
- [FR-4192](https://frontegg.atlassian.net/browse/FR-4192) - change magic link text - [6168fc24](https://github.com/frontegg/admin-box/pulls?q=6168fc24)