### PR TITLE
Update Frontegg AdminPortal to 4.21.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "4.20.0",
+    "@frontegg/react-hooks": "4.21.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "4.19.0",
+    "@frontegg/react-hooks": "4.20.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.19.0",
-    "@frontegg/react-hooks": "4.19.0"
+    "@frontegg/admin-portal": "4.20.0",
+    "@frontegg/react-hooks": "4.20.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.20.0",
-    "@frontegg/react-hooks": "4.20.0"
+    "@frontegg/admin-portal": "4.21.0",
+    "@frontegg/react-hooks": "4.21.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.19.0",
-    "@frontegg/react-hooks": "4.19.0",
+    "@frontegg/admin-portal": "4.20.0",
+    "@frontegg/react-hooks": "4.20.0",
     "react-router-dom": ">5.0.0"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.20.0",
-    "@frontegg/react-hooks": "4.20.0",
+    "@frontegg/admin-portal": "4.21.0",
+    "@frontegg/react-hooks": "4.21.0",
     "react-router-dom": ">5.0.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,44 +2998,44 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.20.0.tgz#9bc50b17fffe66b5708f2f63a6e0513b5186fd18"
-  integrity sha512-ZC/VN2ADA6s36qXSEv7qgTLULVGn1fjD3JKAnFx7kd0wDm9MDoNASN6uTBsUfNz89++FeGvxMRw/hqVT+3ocvA==
+"@frontegg/admin-portal@4.21.0":
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.21.0.tgz#0b6d19fa47e09cd9d1c0b9085f19d932a5cb2478"
+  integrity sha512-Kjp1PFDJs/vo2pKmEzzeNlB3jKSQUCb4wTgpb6Bj7Iutprn/Yat08i2/Errjxvv90JBXrfrfJSKkCz4G5sXIlg==
   dependencies:
-    "@frontegg/redux-store" "4.20.0"
-    "@frontegg/types" "4.20.0"
+    "@frontegg/redux-store" "4.21.0"
+    "@frontegg/types" "4.21.0"
 
-"@frontegg/react-hooks@4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.20.0.tgz#be60824d9fef9548d187c5a31ebc3b37f25a16d0"
-  integrity sha512-6A0quXw/HUDFhuogKILQgMhWpJNwiRfaLOslEFnbB7Xu6RFoVcsGc/5QwCLumExlSWLSCvB7r7WYvuoXo2VS5w==
+"@frontegg/react-hooks@4.21.0":
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.21.0.tgz#22ed79620bc5376fea76911514294ea99344ec1c"
+  integrity sha512-ONrS4F82qyViv5aQH7kmD8h75PSJ5lArcNOawJFu/jeGtuM9Iaqjwiz8QGyXkJEGRGBl9AAjqOhLyljHykQXsA==
   dependencies:
-    "@frontegg/redux-store" "4.20.0"
+    "@frontegg/redux-store" "4.21.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.20.0.tgz#7c1a75a523a2df7009aa01c7554ca1a61b0f5d61"
-  integrity sha512-jve2M4fNtt1VpbVzCMgOJe8DN1+NY4UtKJwBNWoUUWsczNV4Rj4kzH59s5UOdCFOyL3jbL8GkeHm/T9/axN2Fg==
+"@frontegg/redux-store@4.21.0":
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.21.0.tgz#eab7979e5ff66bab87876224fc6de5cdec2232d5"
+  integrity sha512-OAAhJlxRR79/QRfhrPFMRFGJF9fHiLdquBnIxQL73gWAeZLin0perYHWrcZSJYkWQGOg4qkxawL1LSrtS59M9Q==
   dependencies:
-    "@frontegg/rest-api" "^2.10.27"
+    "@frontegg/rest-api" "^2.10.30"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
     tslib "^2.1.0"
     uuid "^8.3.0"
 
-"@frontegg/rest-api@^2.10.27":
-  version "2.10.29"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.29.tgz#759c24f1e1b408506e66c65b01a61d8d7895ca07"
-  integrity sha512-9CCbQCkUym3zVfXUmUR80fVeY+azMoKhU28tqDtI1Sne6KM+ltsS0jh56/w+GiA03MXFwAjzd8Vh//ez6U5CLQ==
+"@frontegg/rest-api@^2.10.30":
+  version "2.10.30"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.30.tgz#db1d6109c7bf79636f931ad0471421a3bd6f043c"
+  integrity sha512-dKiuiUhdFBTLJ7D2vehYjFoByeYzRoV0/yv30Y1Am2C6LBfl5GPagWfvWKBvvlIm3Snn0oH/60WC/efDhdc2dA==
   dependencies:
     tslib "^2.3.0"
 
-"@frontegg/types@4.20.0":
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.20.0.tgz#14081e90780c1bde1267eae75ed3b2cc1c89a57b"
-  integrity sha512-o3mdViAAnlRLUe8MwgaqTibcg0+b5bI177A5DtMkU8Qd/igr8zRaudA3zuNqq73nnRe6DEEuzYMqvQveFTZNxA==
+"@frontegg/types@4.21.0":
+  version "4.21.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.21.0.tgz#ff2b9cddf3e088e08e7aff18554b034b8ed27357"
+  integrity sha512-Org8h8boPAsRLAjW2XIvpMRmx7wmDOH71A+ZTOXke4e8O3pzhGi79v0JDGkFJnu4fpeW1XrXKGNsWZHg7Xib9w==
   dependencies:
     csstype "^3.0.8"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,26 +2998,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.19.0.tgz#504d898b4ca8f3cb793b87c372e5e3d20dcd7305"
-  integrity sha512-8pgA08X5G3HQ0Hw933jVmUlZuebMUv0wHsSmNmx9KOxKZ3LT+W4CgSKpi9Fe4KdXVv9ia1e6y317WNlDNpAr5g==
+"@frontegg/admin-portal@4.20.0":
+  version "4.20.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.20.0.tgz#9bc50b17fffe66b5708f2f63a6e0513b5186fd18"
+  integrity sha512-ZC/VN2ADA6s36qXSEv7qgTLULVGn1fjD3JKAnFx7kd0wDm9MDoNASN6uTBsUfNz89++FeGvxMRw/hqVT+3ocvA==
   dependencies:
-    "@frontegg/redux-store" "4.19.0"
-    "@frontegg/types" "4.19.0"
+    "@frontegg/redux-store" "4.20.0"
+    "@frontegg/types" "4.20.0"
 
-"@frontegg/react-hooks@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.19.0.tgz#37125328bcd44660ef6e6e20420dda9645034336"
-  integrity sha512-P72DA8u2fdHXjaClFDHjTZfuYHeDVo1NiwchobYSVqMDelr1G6qkBIbAX9xQp+UkYR4/TfjBEF1fQz8tFsXPYg==
+"@frontegg/react-hooks@4.20.0":
+  version "4.20.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.20.0.tgz#be60824d9fef9548d187c5a31ebc3b37f25a16d0"
+  integrity sha512-6A0quXw/HUDFhuogKILQgMhWpJNwiRfaLOslEFnbB7Xu6RFoVcsGc/5QwCLumExlSWLSCvB7r7WYvuoXo2VS5w==
   dependencies:
-    "@frontegg/redux-store" "4.19.0"
+    "@frontegg/redux-store" "4.20.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.19.0.tgz#6d9eba23321da92de4a6056dbb6debcda0b9d35d"
-  integrity sha512-UZVyhLt+G9ckiI0N8itrXluvYkzv1DtVxLChcvwMuUXA4uBQU9mJQT9/T2CIZZAoeth7JDXY+Dzleeb2O6d24A==
+"@frontegg/redux-store@4.20.0":
+  version "4.20.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.20.0.tgz#7c1a75a523a2df7009aa01c7554ca1a61b0f5d61"
+  integrity sha512-jve2M4fNtt1VpbVzCMgOJe8DN1+NY4UtKJwBNWoUUWsczNV4Rj4kzH59s5UOdCFOyL3jbL8GkeHm/T9/axN2Fg==
   dependencies:
     "@frontegg/rest-api" "^2.10.27"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3032,10 +3032,10 @@
   dependencies:
     tslib "^2.3.0"
 
-"@frontegg/types@4.19.0":
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.19.0.tgz#5b4226a00d74e217d5e94d50daf5b7de28eb3929"
-  integrity sha512-MlsKj9eScJDGo0w8noLZPSTXLqdTOOCd+7kImQxWXvRiNrnO6fYzdoVD2udUcLFjqNYTspEXHB0bR3fIph+Wag==
+"@frontegg/types@4.20.0":
+  version "4.20.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.20.0.tgz#14081e90780c1bde1267eae75ed3b2cc1c89a57b"
+  integrity sha512-o3mdViAAnlRLUe8MwgaqTibcg0+b5bI177A5DtMkU8Qd/igr8zRaudA3zuNqq73nnRe6DEEuzYMqvQveFTZNxA==
   dependencies:
     csstype "^3.0.8"
 


### PR DESCRIPTION
### AdminPortal 4.21.0:
- [FR-4274](https://frontegg.atlassian.net/browse/FR-4274) - add no local logins strategy - [1a14bd1b](https://github.com/frontegg/admin-box/pulls?q=1a14bd1b)

### AdminPortal 4.20.0:
- [FR-4326](https://frontegg.atlassian.net/browse/FR-4326) - disable refresh token if hosted login - [d452149e](https://github.com/frontegg/admin-box/pulls?q=d452149e)
- [FR-4234](https://frontegg.atlassian.net/browse/FR-4234) - fix alert message design - [1aec3166](https://github.com/frontegg/admin-box/pulls?q=1aec3166)
- [FR-3678](https://frontegg.atlassian.net/browse/FR-3678) - add mock data for subscriptions demo mode - [4512dc3f](https://github.com/frontegg/admin-box/pulls?q=4512dc3f)