### PR TITLE
Update Frontegg AdminPortal to 4.22.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "4.21.2",
+    "@frontegg/react-hooks": "4.22.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.21.2",
-    "@frontegg/react-hooks": "4.21.2"
+    "@frontegg/admin-portal": "4.22.0",
+    "@frontegg/react-hooks": "4.22.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.21.2",
-    "@frontegg/react-hooks": "4.21.2",
+    "@frontegg/admin-portal": "4.22.0",
+    "@frontegg/react-hooks": "4.22.0",
     "react-router-dom": ">5.0.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,26 +2998,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@4.21.2":
-  version "4.21.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.21.2.tgz#52be0c83630837f9d00ef02e0e4a8a45f9510a77"
-  integrity sha512-2vuGOHuEryexV7jB/as2byfCrDGTkUfz37Jf8bvHjbKW1hr0QLSOaYwRWr24hydmk88/4p4mjdJCc+BDJTzXtg==
+"@frontegg/admin-portal@4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.22.0.tgz#000a8fa94715454d995cab5adcf60584ff19d27a"
+  integrity sha512-xjxfnD7Et9/Dk0/TrCQiGLF2OwPqOi+zJTMx8AKcqWgYEw0SyI29YUhpswIPlkay8NI1qPQ3xYMcxXISkPGwSQ==
   dependencies:
-    "@frontegg/redux-store" "4.21.2"
-    "@frontegg/types" "4.21.2"
+    "@frontegg/redux-store" "4.22.0"
+    "@frontegg/types" "4.22.0"
 
-"@frontegg/react-hooks@4.21.2":
-  version "4.21.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.21.2.tgz#fbb81fcc949aaa42bedb9d89688d762586ecbcdc"
-  integrity sha512-xb1wBtYHLQ3Z6fkyklfeyYEhCZY5NsA+q5Dl/rMd+5boIso2nVhSUuqoXveIvcrBkpyLhrvmCXieuteK1+za+g==
+"@frontegg/react-hooks@4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.22.0.tgz#716b2194a6e20c988f54b0bb2e5137225ff4ae0a"
+  integrity sha512-qGEXxXO0/uSzR0zo1Uh5pApfBJXpQKEiiRTiNfUEAk87XUdlzY23pEheyhuByrL18a/pCPY3D1aHBwnAbSjeqQ==
   dependencies:
-    "@frontegg/redux-store" "4.21.2"
+    "@frontegg/redux-store" "4.22.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@4.21.2":
-  version "4.21.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.21.2.tgz#9fd60b8bad1ff657771bbbe76922d7da26b88b15"
-  integrity sha512-ZNxoVkRpg4TuUMMPqCq4unnhSsqI1LDlkrgu/E7QVzEKr5y5+sn2wtAP0HTNqmmjgjtFhkalMPKJZwgPEIDdIw==
+"@frontegg/redux-store@4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.22.0.tgz#8b1b2296ce6ea397f6854bd8ebf6987621bc3fc3"
+  integrity sha512-7ZupD0pa+l6BBrmlotQCdHrl7UgTCCUxo/tsUNiyUj7uJkL8GAkA/yT0pxwv0jVKfDQhkN55dmKlUgNjO+ThnA==
   dependencies:
     "@frontegg/rest-api" "^2.10.30"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3032,10 +3032,10 @@
   dependencies:
     tslib "^2.3.0"
 
-"@frontegg/types@4.21.2":
-  version "4.21.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.21.2.tgz#63faf0189cf7d6a66d8a6d2d884c76e0bbafd556"
-  integrity sha512-O9MK9gCY19MTb7gUELoOl38gT8xglBNvgsWPWV9eg47s5lJGmZ9btnyPKNta6XXah3YRYNM/TAHyLT8pj5FuhA==
+"@frontegg/types@4.22.0":
+  version "4.22.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.22.0.tgz#b7d04dd95ae8cc11e2f205e4da9435836b2326f1"
+  integrity sha512-ESpJjKdfLUHUGZJViyXPAGY5nQNIPa4SBKP0GBHQkKWs+TzMEsMiduR2pw0V0QUHFRjaGxQRelWaiwLeoKRuEA==
   dependencies:
     csstype "^3.0.8"
 


### PR DESCRIPTION
### AdminPortal 4.22.0:
- [FR-4296](https://frontegg.atlassian.net/browse/FR-4296) - enter submit - [17a4ac26](https://github.com/frontegg/admin-box/pulls?q=17a4ac26)
- [FR-4074](https://frontegg.atlassian.net/browse/FR-4074) - build inline dynamic imports to support vitejs build - [e43991a6](https://github.com/frontegg/admin-box/pulls?q=e43991a6)