### PR TITLE
Update Frontegg AdminPortal to 4.35.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "4.34.0",
+    "@frontegg/react-hooks": "4.35.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.34.0",
-    "@frontegg/react-hooks": "4.34.0"
+    "@frontegg/admin-portal": "4.35.0",
+    "@frontegg/react-hooks": "4.35.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.34.0",
-    "@frontegg/react-hooks": "4.34.0",
+    "@frontegg/admin-portal": "4.35.0",
+    "@frontegg/react-hooks": "4.35.0",
     "react-router-dom": ">5.0.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,26 +2998,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@4.34.0":
-  version "4.34.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.34.0.tgz#d06f756478abee7295710858de4edab6abb373f7"
-  integrity sha512-DbxQ7Ua7gxDSp0IpHkYtPXJexjm6OjikAfQu4aKG4scO1XOGvg50N4aEOiayXe6+YwaDtLO39ndnjryOE0obQg==
+"@frontegg/admin-portal@4.35.0":
+  version "4.35.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.35.0.tgz#aed3b87bc0793bde99ffe8844c7a9d116d4daf65"
+  integrity sha512-IXjwLQh9qsLadQgus2AGO6aBuGZ0Ck1zXk3+dRFkYDI/gh+ICXyuZKIqXRdgnasURrwVWg/F6R7mNaFxjf1bzw==
   dependencies:
-    "@frontegg/react-hooks" "4.34.0"
-    "@frontegg/types" "4.34.0"
+    "@frontegg/react-hooks" "4.35.0"
+    "@frontegg/types" "4.35.0"
 
-"@frontegg/react-hooks@4.34.0":
-  version "4.34.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.34.0.tgz#15e7b90217626f46fbf823f35fd7a3c2625f536e"
-  integrity sha512-gYqkwFy/EW0ghg8QGw77Rg1Xbs7LVA+U9zE1t3SiQxclXCCg24ngSYZykkh1CkmxFCnbzIRSWcUrKECg3Vn/YQ==
+"@frontegg/react-hooks@4.35.0":
+  version "4.35.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.35.0.tgz#8bbb88333fc50e384c1a3a65579cddce9a1412ab"
+  integrity sha512-TrmPhzNvNGLm4XRazRm7KR0KBLmIgZ/YGbAmWuMsqyNLIU6le5pn+/GFYaVz44T77UZv8tva8uv8sD72XPVQCw==
   dependencies:
-    "@frontegg/redux-store" "4.34.0"
+    "@frontegg/redux-store" "4.35.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@4.34.0":
-  version "4.34.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.34.0.tgz#07d0174bb1f5e53445bbf690e76bafbf16eb4c23"
-  integrity sha512-tR67qsBOXmT2SvY+VQ3ttDYbeZmw1jtIQakIVK3i8OGITfWdSbPISGhlUOLYJtVW73EjfPuUsJVZzULH/iLMvg==
+"@frontegg/redux-store@4.35.0":
+  version "4.35.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.35.0.tgz#39fa8175d9e6f3b18c5c72186a2536c48f9cb3a5"
+  integrity sha512-qVVwrNraTdu0yGfFYia84EyXapVyZfHwrm+53iQiXLaUL8ukg3a9DqGjQ/Oc6wdm3dB93FuRwyIyoHbk0DHwJQ==
   dependencies:
     "@frontegg/rest-api" "2.10.43"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3030,10 +3030,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.43.tgz#d58062078246c2a496c17e1fe2c3533e555060dc"
   integrity sha512-V+X+rxpkM8+cPEW4DId/SnuHTBHiIIcghYUF7RI+KkpvmUBVLbmo7q3XYnTKVijXP4FHIYChbAeRBnT5fXS80A==
 
-"@frontegg/types@4.34.0":
-  version "4.34.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.34.0.tgz#42e9427b9ef9a46c36f918577372f7803cedb1c3"
-  integrity sha512-VyA67ZfFYAEz992qw3BZ3vzW8VGgTL1H5AJ1ZZCD7qxtZU63xTb4FoDUmkxOxu5mVYOM6gaTMS99IIOIftBD0g==
+"@frontegg/types@4.35.0":
+  version "4.35.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.35.0.tgz#929124688dadc675bc3187cefc0d814bd6b85319"
+  integrity sha512-a0lqz94brvPWJ1H52e48ImRenGh8jZHbT2i0GJggHdf5kdVmXhNYaD8V2BOC+os3t5LbGECIA59lENmDX2M9OQ==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 4.35.0:
- [FR-4576](https://frontegg.atlassian.net/browse/FR-4576) - add mock saga to loadPublicSecurityPolicy - [642e1e91](https://github.com/frontegg/admin-box/pulls?q=642e1e91)
- [FR-4557](https://frontegg.atlassian.net/browse/FR-4557) - fix wrong import of hasPermission - [057046e4](https://github.com/frontegg/admin-box/pulls?q=057046e4)
- [FR-4160](https://frontegg.atlassian.net/browse/FR-4160) - show only active IDPS - [aa24e9c1](https://github.com/frontegg/admin-box/pulls?q=aa24e9c1)
- [FR-4352](https://frontegg.atlassian.net/browse/FR-4352) - error naming + remove old checkout form - [291daaf3](https://github.com/frontegg/admin-box/pulls?q=291daaf3)
- [FR-4355](https://frontegg.atlassian.net/browse/FR-4355) - add usePermission hook, refactor code, some fixes - [efc00ff5](https://github.com/frontegg/admin-box/pulls?q=efc00ff5)
- [FR-4379](https://frontegg.atlassian.net/browse/FR-4379) - handle wrong file type for saml - [351c2043](https://github.com/frontegg/admin-box/pulls?q=351c2043)
- [FR-4334](https://frontegg.atlassian.net/browse/FR-4334) - Double load page bug - [15ba5123](https://github.com/frontegg/admin-box/pulls?q=15ba5123)
- [FR-2912](https://frontegg.atlassian.net/browse/FR-2912) - delete workspace - [ee274186](https://github.com/frontegg/admin-box/pulls?q=ee274186)