### PR TITLE
Update Frontegg AdminPortal to 4.36.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "4.36.0",
+    "@frontegg/react-hooks": "4.36.1",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.36.0",
-    "@frontegg/react-hooks": "4.36.0"
+    "@frontegg/admin-portal": "4.36.1",
+    "@frontegg/react-hooks": "4.36.1"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.36.0",
-    "@frontegg/react-hooks": "4.36.0",
+    "@frontegg/admin-portal": "4.36.1",
+    "@frontegg/react-hooks": "4.36.1",
     "react-router-dom": ">5.0.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,26 +2998,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@4.36.0":
-  version "4.36.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.36.0.tgz#9acae6213a74328b6482bc64b75908b1d7fab55c"
-  integrity sha512-TIZdT7KaTNIWO2CmyXiyr7CFoB0mIvqtzWm4WMPYT3eKoleLySAwbzl7ovO9T7sZTlohZdS+TlLUEt8FosD6Xg==
+"@frontegg/admin-portal@4.36.1":
+  version "4.36.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.36.1.tgz#3859535f8db0a8765c579394cd3d761c8c758377"
+  integrity sha512-A1zvGXJGzT7YIt2vK1Y6awBif4HqOMNm9yq3gkKWm3kt8LrIsvJJbTjZ+wygsASbBEj0SsLaTxSIlQvDwlMg0w==
   dependencies:
-    "@frontegg/react-hooks" "4.36.0"
-    "@frontegg/types" "4.36.0"
+    "@frontegg/react-hooks" "4.36.1"
+    "@frontegg/types" "4.36.1"
 
-"@frontegg/react-hooks@4.36.0":
-  version "4.36.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.36.0.tgz#1f679d52e355dfad8c6450b8d6f709c76bb98eb8"
-  integrity sha512-LSV/7OowtCc8s3y7/LzNd4iFgmydKlrQQLQmxm/E7cKIFzCR7D6zPEVIeRnW3/TM0W+N9ze85f7m9b90okcI8w==
+"@frontegg/react-hooks@4.36.1":
+  version "4.36.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.36.1.tgz#10e8c3abebad20ddfccb75c940010e73fc8a8b8d"
+  integrity sha512-dE9jE2NAhGcBWHtrkAHyXvY4mTjm6EKmP74veh+vtaqimfCToB/CExcjwG5wUEO+9D7BukTyYsgOe6dG5ksfIg==
   dependencies:
-    "@frontegg/redux-store" "4.36.0"
+    "@frontegg/redux-store" "4.36.1"
     react-redux "^7.x"
 
-"@frontegg/redux-store@4.36.0":
-  version "4.36.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.36.0.tgz#073d534c0ebb3f4686044f9ad7b6cbaef7e12c55"
-  integrity sha512-hi6sV6k0F5sxFjiL212uP+doYmrlTWTg//fRxORHTcTlzncKzD1reVu1oXVFqFNvU6SqApGUfuD88ADDWHpGcA==
+"@frontegg/redux-store@4.36.1":
+  version "4.36.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.36.1.tgz#1a8ccced5009276d59ba6f957c6eaf2d24cf1f5b"
+  integrity sha512-mPzhSRty2T/CbejIZrSWxhViIArLLktRfRR6t1+TpLujFqlDBh/S/YscQQEIIX/nq9uwq4biD/mN+gQX0fBXyg==
   dependencies:
     "@frontegg/rest-api" "2.10.43"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3030,10 +3030,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.43.tgz#d58062078246c2a496c17e1fe2c3533e555060dc"
   integrity sha512-V+X+rxpkM8+cPEW4DId/SnuHTBHiIIcghYUF7RI+KkpvmUBVLbmo7q3XYnTKVijXP4FHIYChbAeRBnT5fXS80A==
 
-"@frontegg/types@4.36.0":
-  version "4.36.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.36.0.tgz#6232e50f72ba24cf4d6b9fd140a02be7346bf7e2"
-  integrity sha512-udaT8+PBUh97okDnNWwRAKQAw4L4sytd0SS3eshoOPQM64Ai6mIFuoCSvERvJmABRZQgK/e3D+zbNLouECjEeQ==
+"@frontegg/types@4.36.1":
+  version "4.36.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.36.1.tgz#8eb8e0ec9755e4f8c144e210581b1927794f2f36"
+  integrity sha512-ZG//x7McrS8tLuY/s3OOLlkTbvPoP6vqzlWR8AiNHKc5B5Ja/1f5J/zxyz3wZJqIVQzlfTSv37+Y/FZ7y2wZgA==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 4.36.1:
- [FR-4630](https://frontegg.atlassian.net/browse/FR-4630) - Fix forget password button click - [d19ab3db](https://github.com/frontegg/admin-box/pulls?q=d19ab3db)

### AdminPortal 4.36.0:
- [FR-4607](https://frontegg.atlassian.net/browse/FR-4607) - fix the bug with security - [75b0ac34](https://github.com/frontegg/admin-box/pulls?q=75b0ac34)
- [FR-4286](https://frontegg.atlassian.net/browse/FR-4286) - add bank icons to payment method - [21565f15](https://github.com/frontegg/admin-box/pulls?q=21565f15)
- [FR-4352](https://frontegg.atlassian.net/browse/FR-4352) - Subscriptions - Slow loading (due to invoices) - [edcf916a](https://github.com/frontegg/admin-box/pulls?q=edcf916a)