### PR TITLE
Update Frontegg AdminPortal to 4.42.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "4.42.0",
+    "@frontegg/react-hooks": "4.42.1",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "4.41.0",
+    "@frontegg/react-hooks": "4.42.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "4.40.1",
+    "@frontegg/react-hooks": "4.41.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.41.0",
-    "@frontegg/react-hooks": "4.41.0"
+    "@frontegg/admin-portal": "4.42.0",
+    "@frontegg/react-hooks": "4.42.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.40.1",
-    "@frontegg/react-hooks": "4.40.1"
+    "@frontegg/admin-portal": "4.41.0",
+    "@frontegg/react-hooks": "4.41.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.42.0",
-    "@frontegg/react-hooks": "4.42.0"
+    "@frontegg/admin-portal": "4.42.1",
+    "@frontegg/react-hooks": "4.42.1"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.40.1",
-    "@frontegg/react-hooks": "4.40.1",
+    "@frontegg/admin-portal": "4.41.0",
+    "@frontegg/react-hooks": "4.41.0",
     "react-router-dom": "^5.0.0"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.41.0",
-    "@frontegg/react-hooks": "4.41.0",
+    "@frontegg/admin-portal": "4.42.0",
+    "@frontegg/react-hooks": "4.42.0",
     "react-router-dom": "^5.0.0"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.42.0",
-    "@frontegg/react-hooks": "4.42.0",
+    "@frontegg/admin-portal": "4.42.1",
+    "@frontegg/react-hooks": "4.42.1",
     "react-router-dom": "^5.0.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,26 +2998,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@4.41.0":
-  version "4.41.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.41.0.tgz#1fc35dfc6c9e95f299ae878ab58067a234633d2f"
-  integrity sha512-cEhXULEFRjzJGWvvTjOravyuowR1NnouzQR/FvNvBnwMFwmEirh3laA5MT2HQm11H+WxJEnNJlExmSHdEcIFqw==
+"@frontegg/admin-portal@4.42.0":
+  version "4.42.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.42.0.tgz#bedbbc4b136e99be741e86f5263d87ad464df19e"
+  integrity sha512-hRossNoUdP8YgsyHbvxq83/E2wiIQt4ngxN0lkPopy/j4e69XceAjYtMWosnkU13rRv28tFT+bVtpCcy+PsZhQ==
   dependencies:
-    "@frontegg/react-hooks" "4.41.0"
-    "@frontegg/types" "4.41.0"
+    "@frontegg/react-hooks" "4.42.0"
+    "@frontegg/types" "4.42.0"
 
-"@frontegg/react-hooks@4.41.0":
-  version "4.41.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.41.0.tgz#cbfcc41482c0aac135ac7fb80bedbef0057e78f4"
-  integrity sha512-0I6WnWZygkFiIltrl/mXw4jUAzdB3RZ/nPP9Aw3/O3fYvnKb+ODeHPOR7IyQrYUSAEJhIYVOWk4d8X5tY/5hjA==
+"@frontegg/react-hooks@4.42.0":
+  version "4.42.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.42.0.tgz#100ec86e87e55dcbd172451698f5b1291d66ed19"
+  integrity sha512-CmsyhrSQ/DCfcelRld7bRNMMNQOapMw4jQ7bPcKtNj1WB4djn5yP/uVSuNYn5dg8dipusv+Kxc0i4ohYPTC+9w==
   dependencies:
-    "@frontegg/redux-store" "4.41.0"
+    "@frontegg/redux-store" "4.42.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@4.41.0":
-  version "4.41.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.41.0.tgz#db74afc74f4ba76adf6aab294aea061bd5812d47"
-  integrity sha512-epn7neFWVeYeo1jhiRgJMUo/w9OhT8BVsegTGm+uG7dJ0hTCXX03TsQaz1/vEw8uYsNuA6Rp8+KdxqBZGTpLSQ==
+"@frontegg/redux-store@4.42.0":
+  version "4.42.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.42.0.tgz#a15e0e18cee0abb0bd771ecc603f2ec78223c720"
+  integrity sha512-5KH1Wd7ctQeqL1wiNs8ZIrQO6YYaReVMk7RtfKBubD0EM4wO2BnJ4FYaNNvUlP4IGw809mnS/KpAqFyaDnSVJQ==
   dependencies:
     "@frontegg/rest-api" "2.10.47"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3030,10 +3030,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.47.tgz#70f096ecfab8c53b909f424a54e5db5fa64e0be3"
   integrity sha512-r42xDO7kvWMBo9s9r/kpvZQjFTUF+qNkK3QkY4vMfyzyW6SdbY9jvitxIfkr3ZgeGwOeqL9MFd/z4T2CkzGJDQ==
 
-"@frontegg/types@4.41.0":
-  version "4.41.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.41.0.tgz#3756526bc1f2c424c65db32db195cd7da80452f8"
-  integrity sha512-UZ9HWlUN7h6RsI/f59Oje6Wn5wENsV52IhL1Rw0/AkRb0E/7M6ZlQXAahlG4KgXJnDN6ERxUJF1VWFleaeufLg==
+"@frontegg/types@4.42.0":
+  version "4.42.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.42.0.tgz#e8ac355e71856cc0765ba49c6f8d25f729a8163a"
+  integrity sha512-USoPIoGCsTS122Xu9mYB28cNGNOmFdAu3lvir8YAK827iwDP6JHNylCLp8jpEhI6A+SairqCCSlAZ+tm+vqSFA==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,26 +2998,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@4.42.0":
-  version "4.42.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.42.0.tgz#bedbbc4b136e99be741e86f5263d87ad464df19e"
-  integrity sha512-hRossNoUdP8YgsyHbvxq83/E2wiIQt4ngxN0lkPopy/j4e69XceAjYtMWosnkU13rRv28tFT+bVtpCcy+PsZhQ==
+"@frontegg/admin-portal@4.42.1":
+  version "4.42.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.42.1.tgz#b5674e296182b9c0ede476b11ed52059b3b5328b"
+  integrity sha512-hdCnaIyBhxP+2comIh4+kyW6+aSdZgoVnpIk/A2DafZNhNX/echAU5mRbSxMVO4BC4n4n4yrV9xWmWok3XtgYQ==
   dependencies:
-    "@frontegg/react-hooks" "4.42.0"
-    "@frontegg/types" "4.42.0"
+    "@frontegg/react-hooks" "4.42.1"
+    "@frontegg/types" "4.42.1"
 
-"@frontegg/react-hooks@4.42.0":
-  version "4.42.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.42.0.tgz#100ec86e87e55dcbd172451698f5b1291d66ed19"
-  integrity sha512-CmsyhrSQ/DCfcelRld7bRNMMNQOapMw4jQ7bPcKtNj1WB4djn5yP/uVSuNYn5dg8dipusv+Kxc0i4ohYPTC+9w==
+"@frontegg/react-hooks@4.42.1":
+  version "4.42.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.42.1.tgz#c90aad7a168b36e156306b0ee081362e15d88b77"
+  integrity sha512-/m8X1PA0S6l11eP0ndaG0u2JGR5qd6Hq7UEs7cksUDbzA1s/tXhXFPl2HWIIzYTzcvS/1Yvn6kOXXgdqESX4Sg==
   dependencies:
-    "@frontegg/redux-store" "4.42.0"
+    "@frontegg/redux-store" "4.42.1"
     react-redux "^7.x"
 
-"@frontegg/redux-store@4.42.0":
-  version "4.42.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.42.0.tgz#a15e0e18cee0abb0bd771ecc603f2ec78223c720"
-  integrity sha512-5KH1Wd7ctQeqL1wiNs8ZIrQO6YYaReVMk7RtfKBubD0EM4wO2BnJ4FYaNNvUlP4IGw809mnS/KpAqFyaDnSVJQ==
+"@frontegg/redux-store@4.42.1":
+  version "4.42.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.42.1.tgz#7fc313b68cdb70772e0e3973981f302c37eedac5"
+  integrity sha512-Di/NibgMI91LQws0Dsx5svT+7DGrR//GfPqUzyebvbtXL8jCz0Jawy3TLueg2lomNZkJUhKiEWdN5KCUnMMKWg==
   dependencies:
     "@frontegg/rest-api" "2.10.47"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3030,10 +3030,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.47.tgz#70f096ecfab8c53b909f424a54e5db5fa64e0be3"
   integrity sha512-r42xDO7kvWMBo9s9r/kpvZQjFTUF+qNkK3QkY4vMfyzyW6SdbY9jvitxIfkr3ZgeGwOeqL9MFd/z4T2CkzGJDQ==
 
-"@frontegg/types@4.42.0":
-  version "4.42.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.42.0.tgz#e8ac355e71856cc0765ba49c6f8d25f729a8163a"
-  integrity sha512-USoPIoGCsTS122Xu9mYB28cNGNOmFdAu3lvir8YAK827iwDP6JHNylCLp8jpEhI6A+SairqCCSlAZ+tm+vqSFA==
+"@frontegg/types@4.42.1":
+  version "4.42.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.42.1.tgz#04413d9fa84fca6e6f60a2990de817daa3dcc2a3"
+  integrity sha512-LrDKzDep8XITOmFLPofWPevwx7eqPgxrZUxzzTQAKPnLToJwy+RIkXk0ZHfNizSeCXTd7+bStwD7HGgjw9kcAQ==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,42 +2998,42 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@4.40.1":
-  version "4.40.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.40.1.tgz#c78a6567212092d7e8679cf5822d0eb814a08ef1"
-  integrity sha512-IsftDxx2feeamGwGTEIHtBHpKXXzrdaNUZgjJAVgqbg5tXSi1jmVmjGvv/zywDhMD9wKb9+5bdEBBx12HvYWaQ==
+"@frontegg/admin-portal@4.41.0":
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.41.0.tgz#1fc35dfc6c9e95f299ae878ab58067a234633d2f"
+  integrity sha512-cEhXULEFRjzJGWvvTjOravyuowR1NnouzQR/FvNvBnwMFwmEirh3laA5MT2HQm11H+WxJEnNJlExmSHdEcIFqw==
   dependencies:
-    "@frontegg/react-hooks" "4.40.1"
-    "@frontegg/types" "4.40.1"
+    "@frontegg/react-hooks" "4.41.0"
+    "@frontegg/types" "4.41.0"
 
-"@frontegg/react-hooks@4.40.1":
-  version "4.40.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.40.1.tgz#30071aba8ee2e45d0ddab177736d6b93e5142ec4"
-  integrity sha512-GoX844Z4D7b6R9OQ4fx9aqHhFICjiOBkKpj4m/xW2Vk6bHme4iQUMxZrkzjGqStnDsJyVmvQj6pcpYaYKB4yYA==
+"@frontegg/react-hooks@4.41.0":
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.41.0.tgz#cbfcc41482c0aac135ac7fb80bedbef0057e78f4"
+  integrity sha512-0I6WnWZygkFiIltrl/mXw4jUAzdB3RZ/nPP9Aw3/O3fYvnKb+ODeHPOR7IyQrYUSAEJhIYVOWk4d8X5tY/5hjA==
   dependencies:
-    "@frontegg/redux-store" "4.40.1"
+    "@frontegg/redux-store" "4.41.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@4.40.1":
-  version "4.40.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.40.1.tgz#4967dbf908265fe3fe6781585b5fd3f72b99f317"
-  integrity sha512-LORW4YScgOUPoZ7HJvJIUi6TZwv1D1n2QznFX4C2ZG666N23NI8ACEfiTW2s+oyd5q30vyk2MFt8Mb/LS/VNoA==
+"@frontegg/redux-store@4.41.0":
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.41.0.tgz#db74afc74f4ba76adf6aab294aea061bd5812d47"
+  integrity sha512-epn7neFWVeYeo1jhiRgJMUo/w9OhT8BVsegTGm+uG7dJ0hTCXX03TsQaz1/vEw8uYsNuA6Rp8+KdxqBZGTpLSQ==
   dependencies:
-    "@frontegg/rest-api" "2.10.46"
+    "@frontegg/rest-api" "2.10.47"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
     tslib "^2.3.1"
     uuid "^8.3.0"
 
-"@frontegg/rest-api@2.10.46":
-  version "2.10.46"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.46.tgz#47d59c385ff96927c5a6c0ae1baec8a01d479c83"
-  integrity sha512-YjQLnPZdH//Gb+b6FgLTDWSoBYFGZe9NqoTS3nuBNsQ+64LNtGH4OKUWU82/iByupPG3Uz7zOZAmxhYlKuEhaQ==
+"@frontegg/rest-api@2.10.47":
+  version "2.10.47"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.47.tgz#70f096ecfab8c53b909f424a54e5db5fa64e0be3"
+  integrity sha512-r42xDO7kvWMBo9s9r/kpvZQjFTUF+qNkK3QkY4vMfyzyW6SdbY9jvitxIfkr3ZgeGwOeqL9MFd/z4T2CkzGJDQ==
 
-"@frontegg/types@4.40.1":
-  version "4.40.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.40.1.tgz#11d494e07eb75816620283a903b4ab17990a3663"
-  integrity sha512-HqwCIAMLMrjjoiA4r/mh79YM3EP/cPI6reFrcdTIuoqs3eQsGJiht9Lq1XTa+ZdXJQd2ekgs3yDnlbKnlBx2/A==
+"@frontegg/types@4.41.0":
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.41.0.tgz#3756526bc1f2c424c65db32db195cd7da80452f8"
+  integrity sha512-UZ9HWlUN7h6RsI/f59Oje6Wn5wENsV52IhL1Rw0/AkRb0E/7M6ZlQXAahlG4KgXJnDN6ERxUJF1VWFleaeufLg==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 4.42.1:
- [FR-4850](https://frontegg.atlassian.net/browse/FR-4850) - remove unused styles - [6ccb99bc](https://github.com/frontegg/admin-box/pulls?q=6ccb99bc)

### AdminPortal 4.42.0:
- [FR-4786](https://frontegg.atlassian.net/browse/FR-4786) - addded another hook on the react-hooks and type - [f3e7e9b7](https://github.com/frontegg/admin-box/pulls?q=f3e7e9b7)

### AdminPortal 4.41.0:
- [FR-4717](https://frontegg.atlassian.net/browse/FR-4717) - fix login error - [94408a24](https://github.com/frontegg/admin-box/pulls?q=94408a24)
- [FR-4786](https://frontegg.atlassian.net/browse/FR-4786) - supporting hosted login on login-box - [70523fdc](https://github.com/frontegg/admin-box/pulls?q=70523fdc)