### PR TITLE
Update Frontegg AdminPortal to 5.3.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "3.0.19",
+  "version": "4.0.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "publishConfig": {

--- a/packages/audits/package.json
+++ b/packages/audits/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frontegg/react-audits",
   "libName": "FronteggAudits",
-  "version": "3.0.19",
+  "version": "4.0.0",
   "author": "Frontegg LTD",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
@@ -17,7 +17,7 @@
     "ua-parser-js": "^0.7.23"
   },
   "devDependencies": {
-    "@frontegg/react-core": "^3.0.19",
+    "@frontegg/react-core": "^4.0.0",
     "@types/google-map-react": "^2.1.0",
     "@types/ua-parser-js": "^0.7.35"
   },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frontegg/react-auth",
   "libName": "FronteggAuth",
-  "version": "3.0.19",
+  "version": "4.0.0",
   "author": "Frontegg LTD",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
@@ -19,7 +19,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@frontegg/react-core": "^3.0.19",
+    "@frontegg/react-core": "^4.0.0",
     "@types/react": "^16.9.19",
     "@types/react-dom": "^16.9.8",
     "@types/react-recaptcha-v3": "^1.1.1",

--- a/packages/auth/src/tests/forget-password-flow.cy-spec.tsx
+++ b/packages/auth/src/tests/forget-password-flow.cy-spec.tsx
@@ -53,7 +53,7 @@ describe('Forgot Password Tests', () => {
     mockAuthApi(false, true);
     cy.route({
       method: 'POST',
-      url: `${IDENTITY_SERVICE}/resources/auth/v1/user/saml/prelogin`,
+      url: `${IDENTITY_SERVICE}/resources/auth/v2/user/sso/prelogin`,
       status: 400,
       response: { address: null },
       delay: 200,

--- a/packages/auth/src/tests/login-flow.cy-spec.tsx
+++ b/packages/auth/src/tests/login-flow.cy-spec.tsx
@@ -157,7 +157,7 @@ describe('Login Tests', () => {
     mockAuthMe();
     cy.route({
       method: 'POST',
-      url: `${IDENTITY_SERVICE}/resources/auth/v1/user/saml/prelogin`,
+      url: `${IDENTITY_SERVICE}/resources/auth/v2/user/sso/prelogin`,
       status: 400,
       response: { address: null },
       delay: 200,
@@ -231,7 +231,7 @@ describe('Login Tests', () => {
     mockAuthApi(false, true);
     cy.route({
       method: 'POST',
-      url: `${IDENTITY_SERVICE}/resources/auth/v1/user/saml/prelogin`,
+      url: `${IDENTITY_SERVICE}/resources/auth/v2/user/sso/prelogin`,
       status: 200,
       response: { address: SSO_PATH },
       delay: 200,
@@ -272,7 +272,7 @@ describe('Login Tests', () => {
     mockAuthApi(false, true);
     cy.route({
       method: 'POST',
-      url: `${IDENTITY_SERVICE}/resources/auth/v1/user/saml/prelogin`,
+      url: `${IDENTITY_SERVICE}/resources/auth/v2/user/sso/prelogin`,
       status: 200,
       response: { address: SSO_PATH },
       delay: 200,
@@ -542,7 +542,7 @@ describe('Login Tests', () => {
     mockAuthApi(false, false, true);
     cy.route({
       method: 'POST',
-      url: `${IDENTITY_SERVICE}/resources/auth/v1/user/saml/prelogin`,
+      url: `${IDENTITY_SERVICE}/resources/auth/v2/user/sso/prelogin`,
       status: 200,
       response: { address: SSO_PATH },
       delay: 200,
@@ -602,7 +602,7 @@ describe('Login Tests', () => {
   //   mockAuthApi(false, false, true);
   //   cy.route({
   //     method: 'POST',
-  //     url: `${IDENTITY_SERVICE}/resources/auth/v1/user/saml/prelogin`,
+  //     url: `${IDENTITY_SERVICE}/resources/auth/v2/user/sso/prelogin`,
   //     status: 200,
   //     response: { address: SSO_PATH },
   //     delay: 200,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frontegg/react-cli",
-  "version": "3.0.19",
+  "version": "4.0.0",
   "author": "Frontegg LTD",
   "scripts": {
     "build": "export NODE_ENV='production'; rm -rf ./dist && rollup -c ../../scripts/rollup-cli.config.js && echo DONE",

--- a/packages/connectivity/package.json
+++ b/packages/connectivity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frontegg/react-connectivity",
   "libName": "FronteggConnectivity",
-  "version": "3.0.19",
+  "version": "4.0.0",
   "author": "Frontegg LTD",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-core": "^3.0.19",
+    "@frontegg/react-core": "^4.0.0",
     "@reduxjs/toolkit": "^1.4.0",
     "classnames": "^2.2.6",
     "react": ">16.8.6"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "5.1.0",
+    "@frontegg/react-hooks": "5.2.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "5.2.0",
+    "@frontegg/react-hooks": "5.3.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "4.43.0",
+    "@frontegg/react-hooks": "5.1.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frontegg/react-core",
   "libName": "FronteggCore",
-  "version": "3.0.19",
+  "version": "4.0.0",
   "author": "Frontegg LTD",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/demo-saas/package.json
+++ b/packages/demo-saas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frontegg/demo-saas",
-  "version": "3.0.19",
+  "version": "4.0.0",
   "private": true,
   "author": "Frontegg LTD",
   "scripts": {
@@ -11,8 +11,8 @@
     "test": "echo 'No Unit Tests'"
   },
   "dependencies": {
-    "@frontegg/react-auth": "^3.0.19",
-    "@frontegg/react-core": "^3.0.19",
+    "@frontegg/react-auth": "^4.0.0",
+    "@frontegg/react-core": "^4.0.0",
     "classnames": "^2.2.6",
     "react": ">16.8.6",
     "react-dom": ">16.8.6",

--- a/packages/elements-material-ui/package.json
+++ b/packages/elements-material-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frontegg/react-elements-material-ui",
   "libName": "FronteggElementsMaterialUi",
-  "version": "3.0.19",
+  "version": "4.0.0",
   "author": "Frontegg LTD",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/elements-semantic/package.json
+++ b/packages/elements-semantic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frontegg/react-elements-semantic",
   "libName": "FronteggElementsSemantic",
-  "version": "3.0.19",
+  "version": "4.0.0",
   "author": "Frontegg LTD",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.2.0",
-    "@frontegg/react-hooks": "5.2.0"
+    "@frontegg/admin-portal": "5.3.0",
+    "@frontegg/react-hooks": "5.3.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.1.0",
-    "@frontegg/react-hooks": "5.1.0"
+    "@frontegg/admin-portal": "5.2.0",
+    "@frontegg/react-hooks": "5.2.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.43.0",
-    "@frontegg/react-hooks": "4.43.0"
+    "@frontegg/admin-portal": "5.1.0",
+    "@frontegg/react-hooks": "5.1.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frontegg/nextjs",
   "libName": "FronteggNextJs",
-  "version": "3.0.19",
+  "version": "4.0.0",
   "author": "Frontegg LTD",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.2.0",
-    "@frontegg/react-hooks": "5.2.0",
+    "@frontegg/admin-portal": "5.3.0",
+    "@frontegg/react-hooks": "5.3.0",
     "react-router-dom": "^5.0.0"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@frontegg/react",
   "libName": "FronteggReact",
-  "version": "3.0.19",
+  "version": "4.0.0",
   "author": "Frontegg LTD",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "4.43.0",
-    "@frontegg/react-hooks": "4.43.0",
+    "@frontegg/admin-portal": "5.1.0",
+    "@frontegg/react-hooks": "5.1.0",
     "react-router-dom": "^5.0.0"
   },
   "peerDependencies": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.1.0",
-    "@frontegg/react-hooks": "5.1.0",
+    "@frontegg/admin-portal": "5.2.0",
+    "@frontegg/react-hooks": "5.2.0",
     "react-router-dom": "^5.0.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,26 +2998,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@4.43.0":
-  version "4.43.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-4.43.0.tgz#e330b3b03eee72f99ec3603c0611f0926acd7f2e"
-  integrity sha512-9G4hbjhx1n9POQYrHdlFkgNbYLcAXV7nwg9blIvieyGfa80Yj8v/KgSkKXFitJ/sK7IeR1onZA3K+XXOayvZyw==
+"@frontegg/admin-portal@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.1.0.tgz#068978e2fb3c3476e90ae55a923eadbc3db40d93"
+  integrity sha512-KhJGreTgXZsxBMxYrBYdY0O66owDijTlF8xedqz8CmYMd2bnasPXoDq/Q8/mgqItBqCWozf67UBGN9fcbqBxFQ==
   dependencies:
-    "@frontegg/react-hooks" "4.43.0"
-    "@frontegg/types" "4.43.0"
+    "@frontegg/react-hooks" "5.1.0"
+    "@frontegg/types" "5.1.0"
 
-"@frontegg/react-hooks@4.43.0":
-  version "4.43.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-4.43.0.tgz#abef9ee178454a2209f4de61712b1fd534073751"
-  integrity sha512-GhxU12lOKcGE1hDyQavh3ZHQzAPoi+x3tdsucRFwveyJbmeJBxl8m8DqiyvGmK8hB5VRXfkcNVdQ97Ao8+uO7Q==
+"@frontegg/react-hooks@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.1.0.tgz#1de195eab92bfdf8762cd7d623be98cc1ba7d63b"
+  integrity sha512-QonbOCd7F5SR7L4EWXRrFXe3YcqLtM2ppc+4UhkTs+qbZr9SFbnqv/usAUgkdHevh5Cnj2v/GH6N6imF0IHBgg==
   dependencies:
-    "@frontegg/redux-store" "4.43.0"
+    "@frontegg/redux-store" "5.1.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@4.43.0":
-  version "4.43.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-4.43.0.tgz#027664bc8b06e92f2ee5ffda68a6af0f88885ba4"
-  integrity sha512-PQwmuzWg6W/S9iIWWlkZQn0uYuIZk+tLKgrIeHlPzR5PPNZ45R/4/CkGitaVnbwytDVFngUTpMuz5R9aDqA/WQ==
+"@frontegg/redux-store@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.1.0.tgz#02470ecae89136d1d53fda5cb12c03667f65fca0"
+  integrity sha512-2qwrAntimIZLMBuxFel579Fl39DYBBUS6dgwWj1cqqoOwUKnCHe3FsYO1Ci2lvNQcOjjQCyRzesB7TX71q3Vog==
   dependencies:
     "@frontegg/rest-api" "2.10.47"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3030,10 +3030,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.47.tgz#70f096ecfab8c53b909f424a54e5db5fa64e0be3"
   integrity sha512-r42xDO7kvWMBo9s9r/kpvZQjFTUF+qNkK3QkY4vMfyzyW6SdbY9jvitxIfkr3ZgeGwOeqL9MFd/z4T2CkzGJDQ==
 
-"@frontegg/types@4.43.0":
-  version "4.43.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-4.43.0.tgz#e610c4c4fb330bc77f46624696e953490d8f6d59"
-  integrity sha512-ySQVfEHEqAGcXojMJdE0MkqAYEk3nNCBX/rdrxeER0WAAB8m1byNSVO+CTf4vlYVpG9lTZXAwxZyQ/HGVHhT1g==
+"@frontegg/types@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.1.0.tgz#9e8ef794ad2ea6173f51b492992cf16a91888a40"
+  integrity sha512-4GrixvSV3LC6aPUDJNEO3zWRw6CcsAPIAJA15EpHEi/zr7qhi+f1FsbYeZ/rAdIkUxUi7hXdRXATlYVx8yEUXQ==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,26 +2998,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.2.0.tgz#47095d7c0ff0b602edf65880eb14c40dd40fca44"
-  integrity sha512-Sbnz2tNFeWO63zEBkJ8K4vQjT0g3WfjvxLDgFGldDRWbRA7evuvOb+1TzORzccbysw/7P8id5xVc27yw5SMjbg==
+"@frontegg/admin-portal@5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.3.0.tgz#9edd0f793d15218dcb38488a038bff4ed7667d97"
+  integrity sha512-Oubflro8dHxZa7dm8whPH3yB23uEXmTCPAJ7s4umGjCecdd22qZHVCB7tFnwZmhrSY+wt5WOsM/ivzkxMOB+2Q==
   dependencies:
-    "@frontegg/react-hooks" "5.2.0"
-    "@frontegg/types" "5.2.0"
+    "@frontegg/react-hooks" "5.3.0"
+    "@frontegg/types" "5.3.0"
 
-"@frontegg/react-hooks@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.2.0.tgz#273b802754f6a3ae696ad837adc9a932357c4a88"
-  integrity sha512-bpMvFTlknTW2TrPyb+2z5WjSv82RbhzjQ2fzc54OvTGSUVf7l0EJXkp6YbzGi+B2xnjrInX4BXj7ue/jvtdYCw==
+"@frontegg/react-hooks@5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.3.0.tgz#29572839271f4f78bf3730be993b66531f51a39e"
+  integrity sha512-54Umy3j/9pVqEeT47YESYOwt6FwiKQQqDKExaSrAGp/h+BMjBCNs7rt4fxvCPXVpZsXoLHL7QvDqRoC+Na1Iqw==
   dependencies:
-    "@frontegg/redux-store" "5.2.0"
+    "@frontegg/redux-store" "5.3.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.2.0.tgz#326a12729ac920bdca8c8e458d4f9f872f7d034b"
-  integrity sha512-nk6mqj+Bd/f3XCM/HGNld4+KKx0PXDJyCkwEE5w4xeIdbpxxbvKiSHFpLhWn7F4JAzzplF7vajRK3qA2ist+ww==
+"@frontegg/redux-store@5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.3.0.tgz#20306b841c57abf485dcb2b18bd76000e32ce401"
+  integrity sha512-y6lZHREfJ9pOKwVTV8xaa7WDtkB4X99wDjjaXnP8xZQuTY6fxa2QRdc2AIKBfRiZysePR4lfxxlLrHs6+nnR4A==
   dependencies:
     "@frontegg/rest-api" "2.10.47"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3030,10 +3030,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.47.tgz#70f096ecfab8c53b909f424a54e5db5fa64e0be3"
   integrity sha512-r42xDO7kvWMBo9s9r/kpvZQjFTUF+qNkK3QkY4vMfyzyW6SdbY9jvitxIfkr3ZgeGwOeqL9MFd/z4T2CkzGJDQ==
 
-"@frontegg/types@5.2.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.2.0.tgz#110971f1d26dadfd2fbbae7f5169b076227f03cd"
-  integrity sha512-rp/p4nHmGuL9vAi/cIz1OXpZkqIYXK8fwvLxUgW2y1s+1BcNxIRrKvWyX8wkkQ/eobHymFZRxSsSYmz/pTHbZg==
+"@frontegg/types@5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.3.0.tgz#7039d97fbd631c78cb8b67c907fc5506796a3cd0"
+  integrity sha512-BgOHytspkdiDIM6bILVkNQxldQzdgFOvfGHxRHbrqcpLKAxHt0SgPGsJvkyGu0PfI8cEPRxaBtQC6s7xHw5S0w==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2998,26 +2998,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.1.0.tgz#068978e2fb3c3476e90ae55a923eadbc3db40d93"
-  integrity sha512-KhJGreTgXZsxBMxYrBYdY0O66owDijTlF8xedqz8CmYMd2bnasPXoDq/Q8/mgqItBqCWozf67UBGN9fcbqBxFQ==
+"@frontegg/admin-portal@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.2.0.tgz#47095d7c0ff0b602edf65880eb14c40dd40fca44"
+  integrity sha512-Sbnz2tNFeWO63zEBkJ8K4vQjT0g3WfjvxLDgFGldDRWbRA7evuvOb+1TzORzccbysw/7P8id5xVc27yw5SMjbg==
   dependencies:
-    "@frontegg/react-hooks" "5.1.0"
-    "@frontegg/types" "5.1.0"
+    "@frontegg/react-hooks" "5.2.0"
+    "@frontegg/types" "5.2.0"
 
-"@frontegg/react-hooks@5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.1.0.tgz#1de195eab92bfdf8762cd7d623be98cc1ba7d63b"
-  integrity sha512-QonbOCd7F5SR7L4EWXRrFXe3YcqLtM2ppc+4UhkTs+qbZr9SFbnqv/usAUgkdHevh5Cnj2v/GH6N6imF0IHBgg==
+"@frontegg/react-hooks@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.2.0.tgz#273b802754f6a3ae696ad837adc9a932357c4a88"
+  integrity sha512-bpMvFTlknTW2TrPyb+2z5WjSv82RbhzjQ2fzc54OvTGSUVf7l0EJXkp6YbzGi+B2xnjrInX4BXj7ue/jvtdYCw==
   dependencies:
-    "@frontegg/redux-store" "5.1.0"
+    "@frontegg/redux-store" "5.2.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.1.0.tgz#02470ecae89136d1d53fda5cb12c03667f65fca0"
-  integrity sha512-2qwrAntimIZLMBuxFel579Fl39DYBBUS6dgwWj1cqqoOwUKnCHe3FsYO1Ci2lvNQcOjjQCyRzesB7TX71q3Vog==
+"@frontegg/redux-store@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.2.0.tgz#326a12729ac920bdca8c8e458d4f9f872f7d034b"
+  integrity sha512-nk6mqj+Bd/f3XCM/HGNld4+KKx0PXDJyCkwEE5w4xeIdbpxxbvKiSHFpLhWn7F4JAzzplF7vajRK3qA2ist+ww==
   dependencies:
     "@frontegg/rest-api" "2.10.47"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3030,10 +3030,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.47.tgz#70f096ecfab8c53b909f424a54e5db5fa64e0be3"
   integrity sha512-r42xDO7kvWMBo9s9r/kpvZQjFTUF+qNkK3QkY4vMfyzyW6SdbY9jvitxIfkr3ZgeGwOeqL9MFd/z4T2CkzGJDQ==
 
-"@frontegg/types@5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.1.0.tgz#9e8ef794ad2ea6173f51b492992cf16a91888a40"
-  integrity sha512-4GrixvSV3LC6aPUDJNEO3zWRw6CcsAPIAJA15EpHEi/zr7qhi+f1FsbYeZ/rAdIkUxUi7hXdRXATlYVx8yEUXQ==
+"@frontegg/types@5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.2.0.tgz#110971f1d26dadfd2fbbae7f5169b076227f03cd"
+  integrity sha512-rp/p4nHmGuL9vAi/cIz1OXpZkqIYXK8fwvLxUgW2y1s+1BcNxIRrKvWyX8wkkQ/eobHymFZRxSsSYmz/pTHbZg==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.3.0:
- [FR-4415](https://frontegg.atlassian.net/browse/FR-4415) - Adjust Theme for onboarding builder - [c6270091](https://github.com/frontegg/admin-box/pulls?q=c6270091)
- [FR-5104](https://frontegg.atlassian.net/browse/FR-5104) - change default navigation metadata - [d1d0170e](https://github.com/frontegg/admin-box/pulls?q=d1d0170e)
- [FR-4517](https://frontegg.atlassian.net/browse/FR-4517) - new sso page - [1733992b](https://github.com/frontegg/admin-box/pulls?q=1733992b)