### PR TITLE
Update Frontegg AdminPortal to 5.15.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "5.14.1",
+    "@frontegg/react-hooks": "5.15.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.14.1",
-    "@frontegg/react-hooks": "5.14.1"
+    "@frontegg/admin-portal": "5.15.0",
+    "@frontegg/react-hooks": "5.15.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.14.1",
-    "@frontegg/react-hooks": "5.14.1"
+    "@frontegg/admin-portal": "5.15.0",
+    "@frontegg/react-hooks": "5.15.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,27 +2991,27 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@5.14.1":
-  version "5.14.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.14.1.tgz#9935e68c61d320ebd8d025b40f82e609831b07c9"
-  integrity sha512-aUD+xhjAvcpP6sZIZYufoHCqRvI8JzKaoTp2Md/6UhKqeVQS/pzjw6gB5iwQyhiRGU9vDWnKfU6s501PDgNibw==
+"@frontegg/admin-portal@5.15.0":
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.15.0.tgz#a359d08223e2915a4ad9007226b6e69f41c5ced9"
+  integrity sha512-t4aHDx+0QWgF46YampQwWShgqCqPejcDlpRlE3H4AGZlF52MKGBp3KylTdRQhNJlU2Nx5ejAxGDfkvT0E353kQ==
   dependencies:
-    "@frontegg/react-hooks" "5.14.1"
-    "@frontegg/types" "5.14.1"
+    "@frontegg/react-hooks" "5.15.0"
+    "@frontegg/types" "5.15.0"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.14.1":
-  version "5.14.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.14.1.tgz#c401bd98fe2a4d591656783ff6a899bb3b54fab4"
-  integrity sha512-5R9BxF97+sJ7M43f9h2FA+urkU7SpAB70af+1+jSAotyI6MFOOY9Gs5jAPJqtZXzHYxxCb3JR0ZRwVjl4He9vw==
+"@frontegg/react-hooks@5.15.0":
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.15.0.tgz#7832f731ec0a1c684161902c2c81c1de02dfde53"
+  integrity sha512-3r3WNdgNfny6nN5OnLAJpJHUKYoqXMiz/Y+Oyk/CzPhxpICn+/LNQtINDmwfe9A4UKqMp1PtDebyBBObrE5YhA==
   dependencies:
-    "@frontegg/redux-store" "5.14.1"
+    "@frontegg/redux-store" "5.15.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.14.1":
-  version "5.14.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.14.1.tgz#21c34a01c3e62bfe52766d13b1d20ddf4046bdcf"
-  integrity sha512-QeRyd0Iibf6xLq+PVmCLKokZwq3/tfZJgrWo5TrKe7cWOmDZUylRMwHqhTieylSxXv32+gRgxlyW3RO/otzfAg==
+"@frontegg/redux-store@5.15.0":
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.15.0.tgz#7117e1e7f3dc41d12f0b1bafa69c1028bfa50090"
+  integrity sha512-GpUwsMYeppy+GDT2sGmTVPqLgIZznqKWqCkeh1aKm1Wg0rOD9LAAYaER+ByqU1MPXquZaCbM0KSESxPFPHQJqQ==
   dependencies:
     "@frontegg/rest-api" "2.10.50"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3024,10 +3024,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.50.tgz#590bec109b10d9d6f513f57e3be17eac213989b6"
   integrity sha512-xVAxEPyjaR9W/WLwkhKMi/ZE5Q4DZW3+v32Y6ZznKcD5+bsKpO/vSpd9k2b6VZ0L9Lx+Ki2VWFSAG1gYNntWpA==
 
-"@frontegg/types@5.14.1":
-  version "5.14.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.14.1.tgz#288d4403c3b8b67d87db0cd63f323890ae1c40df"
-  integrity sha512-KCY8ixdTOEspFf9xq5mNemyIeGuprkqGosNx0YwpspgkSwzSA5ZZzpxl51atMnS1gUYKRpGfO6StJiaDq5CpQQ==
+"@frontegg/types@5.15.0":
+  version "5.15.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.15.0.tgz#5767380e34abd765e70c309691ce5a7f44f63497"
+  integrity sha512-fVaWv8OMujdF+lZwmcqpkDsmRF10qrek8EM7PFegh8Kk4CGq3fnNfEqShNcvFsL9YzrLQN2V2gvLv7l5eaiDyA==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.15.0:
- [FR-5617](https://frontegg.atlassian.net/browse/FR-5617) - add auto foucs to mfa - [5fa73d32](https://github.com/frontegg/admin-box/pulls?q=5fa73d32)
- [FR-5558](https://frontegg.atlassian.net/browse/FR-5558) - saml callback - [e1d8b400](https://github.com/frontegg/admin-box/pulls?q=e1d8b400)
- [FR-5602](https://frontegg.atlassian.net/browse/FR-5602) - trim trailing slash from base url passed to options - [01027f4e](https://github.com/frontegg/admin-box/pulls?q=01027f4e)