### PR TITLE
Update Frontegg AdminPortal to 5.17.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "5.16.5",
+    "@frontegg/react-hooks": "5.17.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.16.5",
-    "@frontegg/react-hooks": "5.16.5"
+    "@frontegg/admin-portal": "5.17.0",
+    "@frontegg/react-hooks": "5.17.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.16.5",
-    "@frontegg/react-hooks": "5.16.5"
+    "@frontegg/admin-portal": "5.17.0",
+    "@frontegg/react-hooks": "5.17.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,27 +2991,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@5.16.5":
-  version "5.16.5"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.16.5.tgz#1edaa539500ee4d984bc646449ae560705aedc4c"
-  integrity sha512-Vl6Jcc4nMArRgVdBoIMyjfvtBZs7PpPNWuouE6Ge1xj7pijNFNiZcZCvmBgg3sERl91ByibnViCRDYHWtXMFnA==
+"@frontegg/admin-portal@5.17.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.17.0.tgz#de21957def201e73825dc82cec5b2c0f6674c1ee"
+  integrity sha512-MNFf0aDQig1NJr+O8CsBDEwWEvuHL87kUgIn7Ot+1tYh6TsCbuES5O/gXmtTOTlPA++JlgTgDFkiERV4K4gPOw==
   dependencies:
-    "@frontegg/react-hooks" "5.16.5"
-    "@frontegg/types" "5.16.5"
+    "@frontegg/types" "5.17.0"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.16.5":
-  version "5.16.5"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.16.5.tgz#8c01b99615f22eabb97653c7a383c90bd5a46ecb"
-  integrity sha512-2E9Cse1J48V08tsBUksMH8c53N94e/6V4RJhFQkYn8eW27qyGImAErqGDhdi4FeM2NdgwI5cnZyZ6SRO6GiUuQ==
+"@frontegg/react-hooks@5.17.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.17.0.tgz#f8769b9f60c26dc0d9082843cd5a05ef1fa02b0f"
+  integrity sha512-BwC+CgZC4Iwe3srIihz0pMydZUZHPEuu/WN02ZcxvFYq5R5nMx9nhHpt58lzMDt5fXW9x03GEvEYog1vAA3+dg==
   dependencies:
-    "@frontegg/redux-store" "5.16.5"
+    "@frontegg/redux-store" "5.17.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.16.5":
-  version "5.16.5"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.16.5.tgz#310079b388b1b69c098f609d6858ba313286be05"
-  integrity sha512-1yInf/qM5uD0OMgaeSg6rWG8a62vmyplDNSGEAVlv1Fsa5CkOH/edb5cWqIb5tY2RctNWIoD8OjoVpHDeVj4kw==
+"@frontegg/redux-store@5.17.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.17.0.tgz#fa992ae2c2a3f5356f129c4c7836062417807a37"
+  integrity sha512-ua7rFbunyggCPUpptRZuOLnzP6ZRP+ipx4IlUZH651JqqzHGPbwzIwMpeyU0bjV4WAM40LfKQZTGOKE5moRxqg==
   dependencies:
     "@frontegg/rest-api" "2.10.51"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3024,10 +3023,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.51.tgz#e938fd5344f78b20bcd308fd9181b16fd2fea62c"
   integrity sha512-yvecsIDJlCTustcuy4Be0KOYP+9rKODEDKm5BR7PqSI7Q35koEBu4XjMdL2BH4fTN5JvmNAQ2TwIY00dN1QIiQ==
 
-"@frontegg/types@5.16.5":
-  version "5.16.5"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.16.5.tgz#b4c600212dc9707c01f7a2e3081b2a344d67e6c1"
-  integrity sha512-n4ZSwCKBvm4L4lLsRMloL6Ew5cim5Ou+7xQJEZYQiq555Yau7s29JJZaIYrZhBG/nWaVYCgFS9g87GRl5D1FCQ==
+"@frontegg/types@5.17.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.17.0.tgz#d50d09b855a4b46be90cf70f6533550090cd2b6a"
+  integrity sha512-jX/ENyDfxksCEz39QaISsFGfSX/zmqlImJUl05zt8oRhh3pwU2KpeZ+DmyQvGTeovZf0yuH5hEYOjcrffpDv+A==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.17.0:
- [FR-5904](https://frontegg.atlassian.net/browse/FR-5904) - User should be able to customize admin portal background color - [21a34f2f](https://github.com/frontegg/admin-box/pulls?q=21a34f2f)