### PR TITLE
Update Frontegg AdminPortal to 5.34.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "5.33.1",
+    "@frontegg/react-hooks": "5.33.2",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "5.33.2",
+    "@frontegg/react-hooks": "5.34.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.33.1",
-    "@frontegg/react-hooks": "5.33.1"
+    "@frontegg/admin-portal": "5.33.2",
+    "@frontegg/react-hooks": "5.33.2"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.33.2",
-    "@frontegg/react-hooks": "5.33.2"
+    "@frontegg/admin-portal": "5.34.0",
+    "@frontegg/react-hooks": "5.34.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.33.2",
-    "@frontegg/react-hooks": "5.33.2"
+    "@frontegg/admin-portal": "5.34.0",
+    "@frontegg/react-hooks": "5.34.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.33.1",
-    "@frontegg/react-hooks": "5.33.1"
+    "@frontegg/admin-portal": "5.33.2",
+    "@frontegg/react-hooks": "5.33.2"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,26 +2991,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@5.33.1":
-  version "5.33.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.33.1.tgz#0137a57d7791d650af58b664cca4b75e0a083c96"
-  integrity sha512-wX9aRE8I8iKQv++aLNG4PLV2sPfKM9Fr9vMOtdZQQIKsUhpELiWZ2y2PlYNYIwRD+oBYtiMr0KHUkgJBhYOPMQ==
+"@frontegg/admin-portal@5.33.2":
+  version "5.33.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.33.2.tgz#7f9005e6316896d7f16e34ba177b06475786ac5c"
+  integrity sha512-uNoNbAKyla/YgTlq/MtzZOWsSRd89yRcZ98S1mIqMMvImyU+T4qZOTfICqSzMemMaRL44CyC/w5ntlGjnw+UoQ==
   dependencies:
-    "@frontegg/types" "5.33.1"
+    "@frontegg/types" "5.33.2"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.33.1":
-  version "5.33.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.33.1.tgz#a162f140b967d3ce10c6456cfbf9c0dc44b46764"
-  integrity sha512-WJZwcQ+ODLRF078TesPB1rTsRM+kHWpqvn2+SSVxM0X9mnwsb0wUY/ZOW4+4MvE4aJCA2h/+4GGxgmmQemE9+A==
+"@frontegg/react-hooks@5.33.2":
+  version "5.33.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.33.2.tgz#5e17f3d97be62d4cb22755628fdaa26da374d6c7"
+  integrity sha512-yylD7Ekpslxy6RO5ve/rf+VeauZ0vrM2TWY79qI3w6bhwj7J5kAzVMZL34JgK9jKUyuQEJqwgjSXmxJBufssKA==
   dependencies:
-    "@frontegg/redux-store" "5.33.1"
+    "@frontegg/redux-store" "5.33.2"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.33.1":
-  version "5.33.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.33.1.tgz#a78ecbab9ff663edbcd0accaddcbc6699622a0ff"
-  integrity sha512-qj8rPqNbEuV96uS7MRb7mLQRTuSz7SnytnhVUG0prDkrbv+V/OJhN4ld8iYr9MXLdfd3/SNec6hib6Q7UNlUTw==
+"@frontegg/redux-store@5.33.2":
+  version "5.33.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.33.2.tgz#830cc12814b0617ecefa60d4bda2706ba32bd20a"
+  integrity sha512-cHDhYKYXZkBXx82g2FBC5RroOgNnAoUTaC8WgLMSGbInbl7KL37T8cKb0yEIOMctFE8JdET6F4LE3llAOA5HLA==
   dependencies:
     "@frontegg/rest-api" "2.10.61"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3023,10 +3023,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.61.tgz#57b5518a2dd46625bf0679d001457900d37561de"
   integrity sha512-WX+onWjovECJ/RCsGiPvd2AtRQIdVFfHS+9c5t2G60MzzbrLIrN/AOcUWOgj1Y+P5xLbfGWwtn/FZflAFK430A==
 
-"@frontegg/types@5.33.1":
-  version "5.33.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.33.1.tgz#fe1f81e139e46725b79aaaac9bf672bb4ecbd06f"
-  integrity sha512-MANd2LfHS4SlsdFYm/bQ/IBfuVm1Yk8hbWGRKPfPd7jES5B3LxfcBG8ph6Sj3M3hFSwXi1maVzfFnboav+MDAQ==
+"@frontegg/types@5.33.2":
+  version "5.33.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.33.2.tgz#cfd87eb9e7eb869fc76fccfee6182c0acf63066d"
+  integrity sha512-ttXSk0C16ZJQwQjQFkQ+pL/SJIBhCHfP2EPUZBniXfWO7c63i3BLeJhOLXdI2L9pvgzoolIonxDiPVzO+tgukA==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,26 +2991,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@5.33.2":
-  version "5.33.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.33.2.tgz#7f9005e6316896d7f16e34ba177b06475786ac5c"
-  integrity sha512-uNoNbAKyla/YgTlq/MtzZOWsSRd89yRcZ98S1mIqMMvImyU+T4qZOTfICqSzMemMaRL44CyC/w5ntlGjnw+UoQ==
+"@frontegg/admin-portal@5.34.0":
+  version "5.34.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.34.0.tgz#ef156b324330ee9e57962e31e6289c5de26a75b7"
+  integrity sha512-56+t92WPCLEfAhx7eWa05jN7n33lxaVwcbvf/jk209ybh0orHBDrkgiTQiEcCNBT9BHB2upS/jbxebRmNvZEnA==
   dependencies:
-    "@frontegg/types" "5.33.2"
+    "@frontegg/types" "5.34.0"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.33.2":
-  version "5.33.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.33.2.tgz#5e17f3d97be62d4cb22755628fdaa26da374d6c7"
-  integrity sha512-yylD7Ekpslxy6RO5ve/rf+VeauZ0vrM2TWY79qI3w6bhwj7J5kAzVMZL34JgK9jKUyuQEJqwgjSXmxJBufssKA==
+"@frontegg/react-hooks@5.34.0":
+  version "5.34.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.34.0.tgz#22e28b79eecb7b6ca7fd073d57819d7386e93068"
+  integrity sha512-ap7+vOvLhVd9PMZrKKU4eRsqBCLBiNW/z7UZbQT9sFiYnYv1f9KVR+V1hTTqSghOmKjRSsOCRc9MBaqfhSWWVw==
   dependencies:
-    "@frontegg/redux-store" "5.33.2"
+    "@frontegg/redux-store" "5.34.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.33.2":
-  version "5.33.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.33.2.tgz#830cc12814b0617ecefa60d4bda2706ba32bd20a"
-  integrity sha512-cHDhYKYXZkBXx82g2FBC5RroOgNnAoUTaC8WgLMSGbInbl7KL37T8cKb0yEIOMctFE8JdET6F4LE3llAOA5HLA==
+"@frontegg/redux-store@5.34.0":
+  version "5.34.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.34.0.tgz#e582180809fbde0fbb994aabe648f45cac2dd752"
+  integrity sha512-onWtBQNmEAKqIPX2WdqyTNPLhZLA4U64soXA1GPuMIs0YgiiKHijcioHaC8qmkTIEN5q/v/1CswKegM0HVVxvA==
   dependencies:
     "@frontegg/rest-api" "2.10.61"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3023,10 +3023,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.61.tgz#57b5518a2dd46625bf0679d001457900d37561de"
   integrity sha512-WX+onWjovECJ/RCsGiPvd2AtRQIdVFfHS+9c5t2G60MzzbrLIrN/AOcUWOgj1Y+P5xLbfGWwtn/FZflAFK430A==
 
-"@frontegg/types@5.33.2":
-  version "5.33.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.33.2.tgz#cfd87eb9e7eb869fc76fccfee6182c0acf63066d"
-  integrity sha512-ttXSk0C16ZJQwQjQFkQ+pL/SJIBhCHfP2EPUZBniXfWO7c63i3BLeJhOLXdI2L9pvgzoolIonxDiPVzO+tgukA==
+"@frontegg/types@5.34.0":
+  version "5.34.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.34.0.tgz#0c1a4579b0c4f22ab0187ad78f61994b6de01d4f"
+  integrity sha512-BdlfRA0WTbmNKfOYakR4Wfhzfnhppl5KdABigTIayGYXhvD96aClQh4fIq2XZxRaqIUne0DlrOHR9bzbre0b+Q==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.34.0:
- [FR-6899](https://frontegg.atlassian.net/browse/FR-6899) - Subscriptions - use cancellation and renewal - [26f32adb](https://github.com/frontegg/admin-box/pulls?q=26f32adb)
- [FR-6899](https://frontegg.atlassian.net/browse/FR-6899) - load properly, information state with managed-subscriptions - [9cc6c080](https://github.com/frontegg/admin-box/pulls?q=9cc6c080)

### AdminPortal 5.33.2:
- [FR-6882](https://frontegg.atlassian.net/browse/FR-6882) - subscription action buttons logic - [36f2696f](https://github.com/frontegg/admin-box/pulls?q=36f2696f)
- [FR-6908](https://frontegg.atlassian.net/browse/FR-6908) - fix routes in case of hosted login box - [fa4df58c](https://github.com/frontegg/admin-box/pulls?q=fa4df58c)