### PR TITLE
Update Frontegg AdminPortal to 5.37.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "5.35.0",
+    "@frontegg/react-hooks": "5.36.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "5.34.1",
+    "@frontegg/react-hooks": "5.35.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "5.36.0",
+    "@frontegg/react-hooks": "5.37.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.34.1",
-    "@frontegg/react-hooks": "5.34.1"
+    "@frontegg/admin-portal": "5.35.0",
+    "@frontegg/react-hooks": "5.35.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.35.0",
-    "@frontegg/react-hooks": "5.35.0"
+    "@frontegg/admin-portal": "5.36.0",
+    "@frontegg/react-hooks": "5.36.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.36.0",
-    "@frontegg/react-hooks": "5.36.0"
+    "@frontegg/admin-portal": "5.37.0",
+    "@frontegg/react-hooks": "5.37.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.35.0",
-    "@frontegg/react-hooks": "5.35.0"
+    "@frontegg/admin-portal": "5.36.0",
+    "@frontegg/react-hooks": "5.36.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.36.0",
-    "@frontegg/react-hooks": "5.36.0"
+    "@frontegg/admin-portal": "5.37.0",
+    "@frontegg/react-hooks": "5.37.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.34.1",
-    "@frontegg/react-hooks": "5.34.1"
+    "@frontegg/admin-portal": "5.35.0",
+    "@frontegg/react-hooks": "5.35.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,26 +2991,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@5.36.0":
-  version "5.36.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.36.0.tgz#d87d4fd0091f7ce21fac3274ccd5b0fbbea4abf4"
-  integrity sha512-BKdHMkhb6n/WqlFuDjLy0hc2ksvWVi6bLPBqEfTJ4q1niyX1T8UE1/n4v2OFfeQb9h0cEX8SqWZSCU5kA//3Rw==
+"@frontegg/admin-portal@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.37.0.tgz#1b9f3b366bbff12cbde69bdd38360ba4de0338ba"
+  integrity sha512-0jUUUgih/NhiqTFPppeBBYy7Wlr62bMb2E05ukr4Fl7XCHxUZYdWJAY4jj4A0CXFBzqxmOplPr8AUTMsxo7u1Q==
   dependencies:
-    "@frontegg/types" "5.36.0"
+    "@frontegg/types" "5.37.0"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.36.0":
-  version "5.36.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.36.0.tgz#1c47242e6aebe15b65c62e265af36b1cb3954d7d"
-  integrity sha512-UK+D7fWHFXtP42w7OZ6LkGXm5aBC7nJDc+VG+laeKa3KSmBzXEGKNYOnVn63NWEecDp3IBtzJG/xcy2iazG0Ng==
+"@frontegg/react-hooks@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.37.0.tgz#9b44eb81067127938186c47132d969ec910d3953"
+  integrity sha512-svH+SFOZZyN+PVDjJoi7W0PuEb3aBn8oi+zfw7SGyNfL/0nx1M+RE5e2ffbzbd78f6rwR6KmWG9qcxiLbC4n+w==
   dependencies:
-    "@frontegg/redux-store" "5.36.0"
+    "@frontegg/redux-store" "5.37.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.36.0":
-  version "5.36.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.36.0.tgz#ff0f5b2e120209536645d2ff839bf14aea055933"
-  integrity sha512-NUeInwwBQe0TqcKaibDBIPBjzcXalEDvSuGfL1Bl2RlNBLfUxJbXIE4/jZ9PvmHv95K0Qn4rQpLkVWR3qFg7AA==
+"@frontegg/redux-store@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.37.0.tgz#4891b59d7babb3fc9160b8105aca4cc4d95d3150"
+  integrity sha512-rm8+KBrUP7UeCPdMpwmhAZCfvnfooLeaMKLSbpORnS17APvt6R7KUa1fAdBPAMMO8EAahnIwcvXqRRJqyijAhw==
   dependencies:
     "@frontegg/rest-api" "2.10.61"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3023,10 +3023,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.61.tgz#57b5518a2dd46625bf0679d001457900d37561de"
   integrity sha512-WX+onWjovECJ/RCsGiPvd2AtRQIdVFfHS+9c5t2G60MzzbrLIrN/AOcUWOgj1Y+P5xLbfGWwtn/FZflAFK430A==
 
-"@frontegg/types@5.36.0":
-  version "5.36.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.36.0.tgz#88096458f7293a8d87abb0f5d98b5d73948d5fe9"
-  integrity sha512-BVbwYvzjQ/6AJF1DyXVVv3kFlXC3hCcP7pB/N7IEXKT6AxadYT0qKRLZznCQxNxIxS28AHR9gFdW5+PVOxSvUg==
+"@frontegg/types@5.37.0":
+  version "5.37.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.37.0.tgz#d4e1f05774153cc9f78129dc8339131b8bf25aed"
+  integrity sha512-NsWYV4zdjis8Vc3FyRTlhkjO/2x4RRfH/bdvDDEvu9Ty55GYQyy5o86tTlHgghLC/FLyMDIKIjufcuiElKng0Q==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,26 +2991,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@5.34.1":
-  version "5.34.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.34.1.tgz#18549609301c5f4e540101920ed9244e29e97968"
-  integrity sha512-kVU+Zz8+j2vtM+f0sf5vLpMbgsIJrddL3EdMkAViGXJYgPazibl7O+vNp99+C0QrKdtLIFhIQUU/2GM6VbrczA==
+"@frontegg/admin-portal@5.35.0":
+  version "5.35.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.35.0.tgz#87d854dc157294d25731fb93a655282c75fa3806"
+  integrity sha512-7AAo039RcYGGrBIPnZYLVpo4KTP2yDPkAkxETJLd0iQruNnwhMdGI3+x5/d9P9yn9Jqpv80D6oHnkKphfVaptA==
   dependencies:
-    "@frontegg/types" "5.34.1"
+    "@frontegg/types" "5.35.0"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.34.1":
-  version "5.34.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.34.1.tgz#73f023dc316947317f0cbd91f3bbedff67e011f1"
-  integrity sha512-i1GbsAeDGEt3L9OzPiClE7HT6bJehirT+zotb9D8WVDVhOWeibKP5fUvZlCTjC+ROZsgnbmNExiit+2Z/L8NIA==
+"@frontegg/react-hooks@5.35.0":
+  version "5.35.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.35.0.tgz#ea8b8340b3843ff9e95b98e9bf872fedc21b5cdd"
+  integrity sha512-8tqyX6nAQddXmt+CGzpp3RWjtP9fJZt7thFP+a1RoSkmWq1QiDQ31tx6ZAkbOSz5fCFDUxTO7j/D+VdbiIEDUg==
   dependencies:
-    "@frontegg/redux-store" "5.34.1"
+    "@frontegg/redux-store" "5.35.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.34.1":
-  version "5.34.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.34.1.tgz#3ecda43ad9970cb1aa12bb2be8161f0a3997b6f9"
-  integrity sha512-fhj3nHLFLZY9ofVYxwRNt0xA7D51tVf+ZmHdmo4MjbL7tzj0sKegQr2v3XEuR3lVlufXwF+VgQZVhdeAHvNT+Q==
+"@frontegg/redux-store@5.35.0":
+  version "5.35.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.35.0.tgz#6e76c3757bb170762d51928109a79fa76b50059e"
+  integrity sha512-24amKAqeEK7yLF+APUG817a3R/S9nkANJQ+nEuqPHoV2B45LYaMnO9tTRys/2skUneRoK8idDvaHhu5k1SRWFg==
   dependencies:
     "@frontegg/rest-api" "2.10.61"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3023,10 +3023,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.61.tgz#57b5518a2dd46625bf0679d001457900d37561de"
   integrity sha512-WX+onWjovECJ/RCsGiPvd2AtRQIdVFfHS+9c5t2G60MzzbrLIrN/AOcUWOgj1Y+P5xLbfGWwtn/FZflAFK430A==
 
-"@frontegg/types@5.34.1":
-  version "5.34.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.34.1.tgz#60692211942cb46220db67c660dfb38e41fc22d5"
-  integrity sha512-U9XdNO7VbKIdHZ7TgGlgrIFVcJvHoqMAbzdY4+xhA7VF1DpYFFaWdapwLo8Eam2ZBs5LeyvE3Pm0DArmDC1/GQ==
+"@frontegg/types@5.35.0":
+  version "5.35.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.35.0.tgz#af72a16193237918b3646d3da2760698e54f8944"
+  integrity sha512-TAL+vNk10LI5yueTjEzZ0Xs/3zEuPEA2W8cOzLOOKhw5XXMB35SZ+DpXohvnp31GRY/WLcSD12VkTKb3VFBy8g==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,26 +2991,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@5.35.0":
-  version "5.35.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.35.0.tgz#87d854dc157294d25731fb93a655282c75fa3806"
-  integrity sha512-7AAo039RcYGGrBIPnZYLVpo4KTP2yDPkAkxETJLd0iQruNnwhMdGI3+x5/d9P9yn9Jqpv80D6oHnkKphfVaptA==
+"@frontegg/admin-portal@5.36.0":
+  version "5.36.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.36.0.tgz#d87d4fd0091f7ce21fac3274ccd5b0fbbea4abf4"
+  integrity sha512-BKdHMkhb6n/WqlFuDjLy0hc2ksvWVi6bLPBqEfTJ4q1niyX1T8UE1/n4v2OFfeQb9h0cEX8SqWZSCU5kA//3Rw==
   dependencies:
-    "@frontegg/types" "5.35.0"
+    "@frontegg/types" "5.36.0"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.35.0":
-  version "5.35.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.35.0.tgz#ea8b8340b3843ff9e95b98e9bf872fedc21b5cdd"
-  integrity sha512-8tqyX6nAQddXmt+CGzpp3RWjtP9fJZt7thFP+a1RoSkmWq1QiDQ31tx6ZAkbOSz5fCFDUxTO7j/D+VdbiIEDUg==
+"@frontegg/react-hooks@5.36.0":
+  version "5.36.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.36.0.tgz#1c47242e6aebe15b65c62e265af36b1cb3954d7d"
+  integrity sha512-UK+D7fWHFXtP42w7OZ6LkGXm5aBC7nJDc+VG+laeKa3KSmBzXEGKNYOnVn63NWEecDp3IBtzJG/xcy2iazG0Ng==
   dependencies:
-    "@frontegg/redux-store" "5.35.0"
+    "@frontegg/redux-store" "5.36.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.35.0":
-  version "5.35.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.35.0.tgz#6e76c3757bb170762d51928109a79fa76b50059e"
-  integrity sha512-24amKAqeEK7yLF+APUG817a3R/S9nkANJQ+nEuqPHoV2B45LYaMnO9tTRys/2skUneRoK8idDvaHhu5k1SRWFg==
+"@frontegg/redux-store@5.36.0":
+  version "5.36.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.36.0.tgz#ff0f5b2e120209536645d2ff839bf14aea055933"
+  integrity sha512-NUeInwwBQe0TqcKaibDBIPBjzcXalEDvSuGfL1Bl2RlNBLfUxJbXIE4/jZ9PvmHv95K0Qn4rQpLkVWR3qFg7AA==
   dependencies:
     "@frontegg/rest-api" "2.10.61"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3023,10 +3023,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.61.tgz#57b5518a2dd46625bf0679d001457900d37561de"
   integrity sha512-WX+onWjovECJ/RCsGiPvd2AtRQIdVFfHS+9c5t2G60MzzbrLIrN/AOcUWOgj1Y+P5xLbfGWwtn/FZflAFK430A==
 
-"@frontegg/types@5.35.0":
-  version "5.35.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.35.0.tgz#af72a16193237918b3646d3da2760698e54f8944"
-  integrity sha512-TAL+vNk10LI5yueTjEzZ0Xs/3zEuPEA2W8cOzLOOKhw5XXMB35SZ+DpXohvnp31GRY/WLcSD12VkTKb3VFBy8g==
+"@frontegg/types@5.36.0":
+  version "5.36.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.36.0.tgz#88096458f7293a8d87abb0f5d98b5d73948d5fe9"
+  integrity sha512-BVbwYvzjQ/6AJF1DyXVVv3kFlXC3hCcP7pB/N7IEXKT6AxadYT0qKRLZznCQxNxIxS28AHR9gFdW5+PVOxSvUg==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.37.0:
- [FR-7057](https://frontegg.atlassian.net/browse/FR-7057) - Handle cancellation modals and state - [2c6967cc](https://github.com/frontegg/admin-box/pulls?q=2c6967cc)
- [FR-6899](https://frontegg.atlassian.net/browse/FR-6899) - use subscription instead of billing - [a78e79fa](https://github.com/frontegg/admin-box/pulls?q=a78e79fa)

### AdminPortal 5.36.0:
- 

### AdminPortal 5.35.0:
- [FR-6899](https://frontegg.atlassian.net/browse/FR-6899) - fix subsription state - [eb346846](https://github.com/frontegg/admin-box/pulls?q=eb346846)
- [FR-6899](https://frontegg.atlassian.net/browse/FR-6899) - subscription load with billing information and tenantId - [31093cef](https://github.com/frontegg/admin-box/pulls?q=31093cef)