### PR TITLE
Update Frontegg AdminPortal to 5.40.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "5.39.2",
+    "@frontegg/react-hooks": "5.40.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.39.2",
-    "@frontegg/react-hooks": "5.39.2"
+    "@frontegg/admin-portal": "5.40.0",
+    "@frontegg/react-hooks": "5.40.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.39.2",
-    "@frontegg/react-hooks": "5.39.2"
+    "@frontegg/admin-portal": "5.40.0",
+    "@frontegg/react-hooks": "5.40.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,42 +2991,42 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@5.39.2":
-  version "5.39.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.39.2.tgz#ad7c00eff9636a7abc921b498f360b6a184124d3"
-  integrity sha512-WMIOAUrdo8X6pA01qthQ32oWvkmZf6KgqG8iYhkq/k4Mogb+5rno2sJlvyhvRlaBciizr91ET0wYxpHymLgBig==
+"@frontegg/admin-portal@5.40.0":
+  version "5.40.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.40.0.tgz#5bd579dd141f81467b6f88df0964ffba7af1d39e"
+  integrity sha512-SktRn5i7JajFaJtlnAOMb19jMqDmyPrLigQkZkAzyvPEdtdCrhJYuLWqqupVJASoDiHPquICm/AIiFdY2qkKaA==
   dependencies:
-    "@frontegg/types" "5.39.2"
+    "@frontegg/types" "5.40.0"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.39.2":
-  version "5.39.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.39.2.tgz#b78dfc6ecfd541cb0546dfdcd84b5f227ce9bcf0"
-  integrity sha512-Q/Qh8USGWUYRy+6VtPp1XhFuUAIfZJw+2CFzdguE/W9SMGZqTKKyIH2xGsLi3v+/cFbx1QjUYopVmcwTfN/YmQ==
+"@frontegg/react-hooks@5.40.0":
+  version "5.40.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.40.0.tgz#7afaabcee39db474fc4b5ee1ccf0942d26bb8f50"
+  integrity sha512-7aBq+oUyRKrPokxTtMw/7RBleXF1UPouFrtFOZwuGSHlDum9ZIutgZQi/DyWu6rsesyta0Ldc7SxITPi+72BSw==
   dependencies:
-    "@frontegg/redux-store" "5.39.2"
+    "@frontegg/redux-store" "5.40.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.39.2":
-  version "5.39.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.39.2.tgz#9fbef44d396b4e822cefe5fd95f86e6d5c711de9"
-  integrity sha512-nRf8Gj5dyO0wGzl8DmQPAeqFrdSWHTyyxTSUjV/FNr+AbAm52xq/KwgIOR0hz9DUEAmLda5BeVI0MPD7y5L/rQ==
+"@frontegg/redux-store@5.40.0":
+  version "5.40.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.40.0.tgz#44d4351f219a52fc2335a2a9cae026f3816561a7"
+  integrity sha512-j22xWUdOoBgiH4+DAnF6CgdWFSfTKxwPP8hmh1/qJzlXqNtFEe/fydLKjnb3PU22Ag0A4Id6UnFt/WeT5F0J5w==
   dependencies:
-    "@frontegg/rest-api" "2.10.61"
+    "@frontegg/rest-api" "2.10.62"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
     tslib "^2.3.1"
     uuid "^8.3.0"
 
-"@frontegg/rest-api@2.10.61":
-  version "2.10.61"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.61.tgz#57b5518a2dd46625bf0679d001457900d37561de"
-  integrity sha512-WX+onWjovECJ/RCsGiPvd2AtRQIdVFfHS+9c5t2G60MzzbrLIrN/AOcUWOgj1Y+P5xLbfGWwtn/FZflAFK430A==
+"@frontegg/rest-api@2.10.62":
+  version "2.10.62"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.62.tgz#00d80be7866f59ea69625adff0181b8090396dc7"
+  integrity sha512-cHFVBUqRB71tb3GYtVL7nXSd3gRQ23q4CfSUCNMcHMypgYqnyVZ3+mReQHZ6djMfqlKsUiB/8DDATkr1XRo9hg==
 
-"@frontegg/types@5.39.2":
-  version "5.39.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.39.2.tgz#9016ed1052a5e7552acc533dd4804b5bdd2a6be0"
-  integrity sha512-1cEUrkNula6g5VO5luDQFDijlsnzEbWYaK94sDPf2tbuwy78Ffjli+V2+iDzdPB3UNvt9N38F3txMs0Ao5UYGw==
+"@frontegg/types@5.40.0":
+  version "5.40.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.40.0.tgz#4ada82aed3aa7c4a32d7adb75e64823ba32b2342"
+  integrity sha512-xZVvjp6zWWNNA4GWGgAkd4mcUZmfNdTLtmUrGY1Bar12ptTwkV/nTBoyR6y9FdiPgG6TNshGGE1pUr8zTqwjRg==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.40.0:
- [FR-7233](https://frontegg.atlassian.net/browse/FR-7233) - Support custom events for user verification and sign up - [c8ef20c1](https://github.com/frontegg/admin-box/pulls?q=c8ef20c1)
- [FR-5604](https://frontegg.atlassian.net/browse/FR-5604) - add support for multiple baseUrl based on url - [ff78ed09](https://github.com/frontegg/admin-box/pulls?q=ff78ed09)