### PR TITLE
Update Frontegg AdminPortal to 5.44.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "5.43.1",
+    "@frontegg/react-hooks": "5.44.1",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.43.1",
-    "@frontegg/react-hooks": "5.43.1"
+    "@frontegg/admin-portal": "5.44.1",
+    "@frontegg/react-hooks": "5.44.1"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.43.1",
-    "@frontegg/react-hooks": "5.43.1"
+    "@frontegg/admin-portal": "5.44.1",
+    "@frontegg/react-hooks": "5.44.1"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,26 +2991,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@5.43.1":
-  version "5.43.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.43.1.tgz#58303e922a86803cde49cbf4f3ef74211c450d57"
-  integrity sha512-b/+V4sbT7yRvqkTggMACQ0q+kogfWaTf5ACcUW/WBe4lhV/Qc2QJuN8+yiS0Qc6vz7RumLlFJ8qt25Rl6/WaZw==
+"@frontegg/admin-portal@5.44.1":
+  version "5.44.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.44.1.tgz#d88007815c6b617c9f81463d26765c1066cc3150"
+  integrity sha512-uDQBTBI2QOOFLgL+Csn84KOKm+khw+ODrKsQFqGVn3rPfouvrxcEfK1dbe1N133QEfKNfJ70DcQuMNLnuSVHMA==
   dependencies:
-    "@frontegg/types" "5.43.1"
+    "@frontegg/types" "5.44.1"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.43.1":
-  version "5.43.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.43.1.tgz#816cbff257ef5e6f23ea50447c642863d9c8af62"
-  integrity sha512-TJd8hKeJObqdUFqQi0RgHEi5blr0bV7dkFbs04Tl0IN4CyVyswsZV23vH5A2wtI8p1xtp0CtyQtpT63kDueOYA==
+"@frontegg/react-hooks@5.44.1":
+  version "5.44.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.44.1.tgz#40618001e66b7e34092cf5cf6b08ae3dc56a38d8"
+  integrity sha512-BGRB4NkPQy/PdteVhWLA0/bAJVlnCxmGaQqAacqEml410FqhPoSJULQrmLaxEwVQaXRpHPEkHN2gyh5SG2V8Dw==
   dependencies:
-    "@frontegg/redux-store" "5.43.1"
+    "@frontegg/redux-store" "5.44.1"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.43.1":
-  version "5.43.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.43.1.tgz#93c18f5550abc2e030f742605e3dcc0938df9208"
-  integrity sha512-gxrTJcZ9zRQ7AJbDgj1uBMZ1mWGXqR4qXux2vdBWYiydOTlCzUq8DztzEiYq2LmYNDAaBYCSpJXBlLNjqXUWkg==
+"@frontegg/redux-store@5.44.1":
+  version "5.44.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.44.1.tgz#dabb31d86ff9b7013ce165e83e80a2a738be7982"
+  integrity sha512-wC1WOQ7iYEnmCzYAFHwjXr8/uEjotQYSYloVU8sKk2awlK+3eyFxZsX+mWbrGS0IA+hldHRCk2tTGjAbnQzSEg==
   dependencies:
     "@frontegg/rest-api" "2.10.64"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3023,10 +3023,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.64.tgz#29d254a379d428439f89e593272a53514dcbd218"
   integrity sha512-VYz2KCxZAPLWq8h8Iq0V1lnUeqMymqc6DCo1y5mxXwjyNeNgNmvAt3IPVGp8WiLjsDgBj1cv3koVnypQRFTzoQ==
 
-"@frontegg/types@5.43.1":
-  version "5.43.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.43.1.tgz#ab52deae5fc7ffec8dc380381f8504cfc6824621"
-  integrity sha512-5D0JphIufcE/pKlpqSVKSAuc97VMbVP5QxY+k//OtYizNZj77x1nRZ/c/GkvKE50sgVdfIoBaQBCKM23c+SeNA==
+"@frontegg/types@5.44.1":
+  version "5.44.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.44.1.tgz#bb7e8aef7c0d8473c60f0b71a3f0bc940ac90fa7"
+  integrity sha512-QxHe+B8R/WIIhe95Sf2pnLwtB9SwA1hha9ZYQF+I0XqWy79ftWT9rsUUW6uLuUV60mJnex76vMeNIiPMe7FZKg==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.44.1:
- [FR-7316](https://frontegg.atlassian.net/browse/FR-7316) - dummy commit to run pipeline again to release admin box version successfully - [07c721da](https://github.com/frontegg/admin-box/pulls?q=07c721da)