### PR TITLE
Update Frontegg AdminPortal to 5.47.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "5.46.0",
+    "@frontegg/react-hooks": "5.47.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "5.45.2",
+    "@frontegg/react-hooks": "5.46.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.45.2",
-    "@frontegg/react-hooks": "5.45.2"
+    "@frontegg/admin-portal": "5.46.0",
+    "@frontegg/react-hooks": "5.46.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.46.0",
-    "@frontegg/react-hooks": "5.46.0"
+    "@frontegg/admin-portal": "5.47.0",
+    "@frontegg/react-hooks": "5.47.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.46.0",
-    "@frontegg/react-hooks": "5.46.0"
+    "@frontegg/admin-portal": "5.47.0",
+    "@frontegg/react-hooks": "5.47.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.45.2",
-    "@frontegg/react-hooks": "5.45.2"
+    "@frontegg/admin-portal": "5.46.0",
+    "@frontegg/react-hooks": "5.46.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,42 +2991,42 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@5.45.2":
-  version "5.45.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.45.2.tgz#d537084c916d36bd89aac2e016e08804e9b37c48"
-  integrity sha512-I3zsSCbtTXIo2RQESFfPnH84DpbVGvEYv3vT85yzRw7hWJS9vjJqpenW622pU9iDYTnrVkLo54lA4wJiPdKgUQ==
+"@frontegg/admin-portal@5.46.0":
+  version "5.46.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.46.0.tgz#bef19276ff58668e2785db085bc7080ec7ffd06c"
+  integrity sha512-MSGgbta1eZK9zBES3nSTSf+s2/9SEeN7uZNk2kG18wbyta8h7RFXCQjMo5sTTcnh2fOVmh1D2GWf1+SK1rDMMA==
   dependencies:
-    "@frontegg/types" "5.45.2"
+    "@frontegg/types" "5.46.0"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.45.2":
-  version "5.45.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.45.2.tgz#b99384c12d5064a3d463c65dbfaca9605e98babb"
-  integrity sha512-N8K7O87o/VHJS1PE7WWFVqyALd1ahyTLtObQTNoSM6RzFdeJjfeohfMmb2FXZvW9XjPdAY4QxvmaeqcSum9m9Q==
+"@frontegg/react-hooks@5.46.0":
+  version "5.46.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.46.0.tgz#822a4cb25d0e7f145475a0c5bbcaa8bd378c1061"
+  integrity sha512-NR2zbZRJD/dv0gL9FJl8VS0H11RN1LUOP27Pml3kZZ2ap2WLIqPbtJYeS0DeE48Et9D1W0cQYY9iCngUfj6CFQ==
   dependencies:
-    "@frontegg/redux-store" "5.45.2"
+    "@frontegg/redux-store" "5.46.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.45.2":
-  version "5.45.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.45.2.tgz#1be455d37c3a9bbd57a26a13bab5894d91ca5159"
-  integrity sha512-7PwMIP1FoZ/8dG52GOGssZ8tcL5iGc7g+eoCJOEKKNauftdDboAQetRtLscIbZdsRAzNmKPNg/qBSSDil0oKbg==
+"@frontegg/redux-store@5.46.0":
+  version "5.46.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.46.0.tgz#f147613989a7fafe25545b7c7c6236238d49b7bb"
+  integrity sha512-LG6ZcFiEzGqynE5G5oHqXw967uoaX8jmZid4NuFV7p1gzAHAQjlnNg3z1Wy0NYVvYkJGIocWUw54PUsHbKXPlg==
   dependencies:
-    "@frontegg/rest-api" "2.10.64"
+    "@frontegg/rest-api" "2.10.65"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
     tslib "^2.3.1"
     uuid "^8.3.0"
 
-"@frontegg/rest-api@2.10.64":
-  version "2.10.64"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.64.tgz#29d254a379d428439f89e593272a53514dcbd218"
-  integrity sha512-VYz2KCxZAPLWq8h8Iq0V1lnUeqMymqc6DCo1y5mxXwjyNeNgNmvAt3IPVGp8WiLjsDgBj1cv3koVnypQRFTzoQ==
+"@frontegg/rest-api@2.10.65":
+  version "2.10.65"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.65.tgz#fc0d14602c0bf2ac46b62ea1c4a90bd8f609d1dc"
+  integrity sha512-wKns7eujRAcJV7gFOQSbckiRKl0qalPfNw8zGk8T0MkfTe2+4tOO0wl/nQP7oB70LdLeQDhgzQwWdS8bihgM3w==
 
-"@frontegg/types@5.45.2":
-  version "5.45.2"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.45.2.tgz#2cd33b38fa4531d5af8474046ff66e8b200f7f41"
-  integrity sha512-+dcaTSkB86Mf8DX/b6tGw+/9ScFNiyLjByc89LBGUNuPA1nwoLR+oBuRkmdoVFDQbfTxe8f0gR5XPibuqUwjOg==
+"@frontegg/types@5.46.0":
+  version "5.46.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.46.0.tgz#d76a571595d96a613334ccdea8aa6adc82f62421"
+  integrity sha512-O2Nw1P5fO7Eui7M0qY4YS2kVZ5hMUbEoVULKVRVhGGNq6wAOY4Mv3s0jqQpLtP4oDsy40vGts272IhEt1ZLeYA==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,26 +2991,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@5.46.0":
-  version "5.46.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.46.0.tgz#bef19276ff58668e2785db085bc7080ec7ffd06c"
-  integrity sha512-MSGgbta1eZK9zBES3nSTSf+s2/9SEeN7uZNk2kG18wbyta8h7RFXCQjMo5sTTcnh2fOVmh1D2GWf1+SK1rDMMA==
+"@frontegg/admin-portal@5.47.0":
+  version "5.47.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.47.0.tgz#5957fb11514a987ea0a68ca7e9e6c111afbac525"
+  integrity sha512-EqnWctrqFsZaZSXidPqTyyN2QdeuyEOvpBmrzEgXQr796cQDujggn2OWJ8pH3tJZlt9ESPwm1kXlCfXje1lA3g==
   dependencies:
-    "@frontegg/types" "5.46.0"
+    "@frontegg/types" "5.47.0"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.46.0":
-  version "5.46.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.46.0.tgz#822a4cb25d0e7f145475a0c5bbcaa8bd378c1061"
-  integrity sha512-NR2zbZRJD/dv0gL9FJl8VS0H11RN1LUOP27Pml3kZZ2ap2WLIqPbtJYeS0DeE48Et9D1W0cQYY9iCngUfj6CFQ==
+"@frontegg/react-hooks@5.47.0":
+  version "5.47.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.47.0.tgz#fd0c3910acf7ae5b063994e9d0bcc54e94a26238"
+  integrity sha512-1nesmyf4tH////57qXwuZ2Ox7vgql+XE3IN+q90tCRophOkyFmeL+7ypQb8DGwL++PCSTnsXL0HTzlAgm48a2g==
   dependencies:
-    "@frontegg/redux-store" "5.46.0"
+    "@frontegg/redux-store" "5.47.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.46.0":
-  version "5.46.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.46.0.tgz#f147613989a7fafe25545b7c7c6236238d49b7bb"
-  integrity sha512-LG6ZcFiEzGqynE5G5oHqXw967uoaX8jmZid4NuFV7p1gzAHAQjlnNg3z1Wy0NYVvYkJGIocWUw54PUsHbKXPlg==
+"@frontegg/redux-store@5.47.0":
+  version "5.47.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.47.0.tgz#b7c738ce31687a9f92997382cffb110487718e64"
+  integrity sha512-J8GKqr+uwhgArujG4Gbv4KUbOX4zfWfZg4yxbTZTqnZEaqZR9HV99CYPSx75ijwRmvnaH1og3c96sag8Xdpb/A==
   dependencies:
     "@frontegg/rest-api" "2.10.65"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3023,10 +3023,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.65.tgz#fc0d14602c0bf2ac46b62ea1c4a90bd8f609d1dc"
   integrity sha512-wKns7eujRAcJV7gFOQSbckiRKl0qalPfNw8zGk8T0MkfTe2+4tOO0wl/nQP7oB70LdLeQDhgzQwWdS8bihgM3w==
 
-"@frontegg/types@5.46.0":
-  version "5.46.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.46.0.tgz#d76a571595d96a613334ccdea8aa6adc82f62421"
-  integrity sha512-O2Nw1P5fO7Eui7M0qY4YS2kVZ5hMUbEoVULKVRVhGGNq6wAOY4Mv3s0jqQpLtP4oDsy40vGts272IhEt1ZLeYA==
+"@frontegg/types@5.47.0":
+  version "5.47.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.47.0.tgz#4d594f25098a40f1da5babd936707943cf08052a"
+  integrity sha512-rQFFQb7q2P8urs5rR7wYzaonbMvFpIPrLwPmkOFeiRCywMqp93Xp8Rb86IpqFVhO+s1avzIEmU+QAE5XvCAVLQ==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.46.0:
- [FR-7306](https://frontegg.atlassian.net/browse/FR-7306) - add RoutesLayoutPreviewMode - [65f5ed80](https://github.com/frontegg/admin-box/pulls?q=65f5ed80)
- [FR-7353](https://frontegg.atlassian.net/browse/FR-7353) - update rest-api version - [11476ed4](https://github.com/frontegg/admin-box/pulls?q=11476ed4)