### PR TITLE
Update Frontegg AdminPortal to 5.50.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "5.49.0",
+    "@frontegg/react-hooks": "5.50.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.49.0",
-    "@frontegg/react-hooks": "5.49.0"
+    "@frontegg/admin-portal": "5.50.0",
+    "@frontegg/react-hooks": "5.50.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.49.0",
-    "@frontegg/react-hooks": "5.49.0"
+    "@frontegg/admin-portal": "5.50.0",
+    "@frontegg/react-hooks": "5.50.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,42 +2991,42 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@5.49.0":
-  version "5.49.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.49.0.tgz#44b878fd1ddc45d73a3634fbf6bcb5be6fedeac9"
-  integrity sha512-AShmwgYYAgOhggc7H5gdH102AvW0xL7Vn6NplZe5gteap9RDkTb9l4ZFe4Lt7qTfAMVQ5a9S0FjbOw/zG4pxyw==
+"@frontegg/admin-portal@5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.50.0.tgz#de421e28cb9f697f43e57d76b6edf0e2664f9c0d"
+  integrity sha512-XVje3DUNFG8SgA3qYc5wzl8e/v18M1CxG+86hFntlmSmqXqZHWUwfEPdx+8I9kBu2IHEP3cVblLnMNOWpgA+XQ==
   dependencies:
-    "@frontegg/types" "5.49.0"
+    "@frontegg/types" "5.50.0"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.49.0":
-  version "5.49.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.49.0.tgz#efc9019613db1d050ab74c08fc1fa115f59ea242"
-  integrity sha512-Emfe+HeqAT6cBAQiflFXv1NHW1JSKjYAxPz7GXrbDCr7od34TyyODdyjNB/dFf++1rpClA6D6UfgmtTGkuNByA==
+"@frontegg/react-hooks@5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.50.0.tgz#d013a1744a9b313c6ba63667fbe4fb2e97be0713"
+  integrity sha512-0Cr8iy0v4w0nAkLzcfie0b1s3bUZCBklVP1fnrt0u9k9qYXIV1y1Fsz0yrL9mWvqpYFU9ISokSFlDYJSSclV5w==
   dependencies:
-    "@frontegg/redux-store" "5.49.0"
+    "@frontegg/redux-store" "5.50.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.49.0":
-  version "5.49.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.49.0.tgz#00dd4e3cd34f1a94d2ddb672c40d335ffbc70038"
-  integrity sha512-W9v274L7x0vNL6399xcCKUciSsok/w55XhFqfQdbT5GrlLKZh4axc64BY4XywWv8ceFmYPrQF5GK+cJ/XBGMRA==
+"@frontegg/redux-store@5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.50.0.tgz#6b07d72cfafe89cfe6cf7e965699384f658e8ebe"
+  integrity sha512-d6SM8AchEzzSTXhrpj71MNsl44lWsagP8RlOb34zL86CzkJpBILXKnncNc1h72o1zq8YghP6wzjlxKKiuzdMqQ==
   dependencies:
-    "@frontegg/rest-api" "2.10.66"
+    "@frontegg/rest-api" "2.10.67"
     "@reduxjs/toolkit" "^1.5.0"
     redux-saga "^1.1.0"
     tslib "^2.3.1"
     uuid "^8.3.0"
 
-"@frontegg/rest-api@2.10.66":
-  version "2.10.66"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.66.tgz#be21930ce6d24883bb74917c2cd407a30ecad0a6"
-  integrity sha512-I9/E3dpN2WNjj3s+dlbZCCF/o3lIDxy1BZPOilfwmdulEF7UtwhBxWLwQgS9cGKA/feWGESnsEX0JFM/SyT6gw==
+"@frontegg/rest-api@2.10.67":
+  version "2.10.67"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.67.tgz#5b6f39fa7dc018f8106add9db96cce341a98af47"
+  integrity sha512-RkNsgD32UUQH+1Q4JIcdoXmlZ0lNtCnECpGjK5Ipq3Lne6fEl/dpd/SRHQ9W0g8WkYXe6GL97S0MfqkHZS76zA==
 
-"@frontegg/types@5.49.0":
-  version "5.49.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.49.0.tgz#fc6d7348f2a44694ecde013cadb9edc497cdc2ef"
-  integrity sha512-Psw0nUE3xl8wBNkmRARCqVzuGIk7SwnT1xafa8aQ7TWfCBuyw/mSYyDYMjPF21a6smnYYfPM8vYAfu5sqTOYwg==
+"@frontegg/types@5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.50.0.tgz#04eda7cf23e798c27217fd5e8eae29ae8ed95911"
+  integrity sha512-agZ6LLAjQmT9QQXxoMtC1YRV430UqsDJewMsy3AaqBq1t9WCWm67JoYBItFIX4JvZFfDxQCmtsogvIdHRIu+Iw==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.50.0:
- [FR-7177](https://frontegg.atlassian.net/browse/FR-7177) - Checkout Dialog w/ Plan Slug - [bf2c3b8a](https://github.com/frontegg/admin-box/pulls?q=bf2c3b8a)
- [FR-6546](https://frontegg.atlassian.net/browse/FR-6546) - fix sso tooltip - [534b6986](https://github.com/frontegg/admin-box/pulls?q=534b6986)
- [FR-7358](https://frontegg.atlassian.net/browse/FR-7358) - subtitle alignment - [44d3a5ca](https://github.com/frontegg/admin-box/pulls?q=44d3a5ca)
- [FR-7165](https://frontegg.atlassian.net/browse/FR-7165) - Update postcode validation - [06e07db2](https://github.com/frontegg/admin-box/pulls?q=06e07db2)