### PR TITLE
Update Frontegg AdminPortal to 5.54.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "5.54.0",
+    "@frontegg/react-hooks": "5.54.1",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "5.53.4",
+    "@frontegg/react-hooks": "5.54.0",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.53.4",
-    "@frontegg/react-hooks": "5.53.4"
+    "@frontegg/admin-portal": "5.54.0",
+    "@frontegg/react-hooks": "5.54.0"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.54.0",
-    "@frontegg/react-hooks": "5.54.0"
+    "@frontegg/admin-portal": "5.54.1",
+    "@frontegg/react-hooks": "5.54.1"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.54.0",
-    "@frontegg/react-hooks": "5.54.0"
+    "@frontegg/admin-portal": "5.54.1",
+    "@frontegg/react-hooks": "5.54.1"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.53.4",
-    "@frontegg/react-hooks": "5.53.4"
+    "@frontegg/admin-portal": "5.54.0",
+    "@frontegg/react-hooks": "5.54.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,26 +2991,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@5.54.0":
-  version "5.54.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.54.0.tgz#0082987f65e5ebea3ef5c65fe9309f15297d3a22"
-  integrity sha512-EKpU77PGw3o1vQR9SqaWow7Hz+jOs4p42IaQDKXHU33f7/Qe4dB6Y/ya1SmylpPvWLzfu24QACxQj84fj9N1kg==
+"@frontegg/admin-portal@5.54.1":
+  version "5.54.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.54.1.tgz#b351095376b76bd586c4d9fc49b7d3abac614bbe"
+  integrity sha512-P7z/+d1kdL36MXCatZAbUrJB43gBmCLsWle2pV95ystODlPr4yyBIw2AmeetX1IFPy0zmZmVQ2Odp4Py3DVhbw==
   dependencies:
-    "@frontegg/types" "5.54.0"
+    "@frontegg/types" "5.54.1"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.54.0":
-  version "5.54.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.54.0.tgz#6ea360cee8656e7ee6ee18b4dfe06ac53b78e88a"
-  integrity sha512-zWEQrJ/dMav0FsdKBhPpBozpJUENtrjb6p/+6BqAob8ogtyEt/WJ6dgdeN/uiLHT8BrgodNZ62yuxPAZEFmCjg==
+"@frontegg/react-hooks@5.54.1":
+  version "5.54.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.54.1.tgz#06e3aec53ae551c6d1d891850df57ca1170b3dec"
+  integrity sha512-t1obMLineOUjn2dN6CBqoBsVpfzTvR/dBHULUCgYwzL8GH7oxvBWGUPNV2NG6RZk6QJ+WkTtxEGaOrRw9z3o5A==
   dependencies:
-    "@frontegg/redux-store" "5.54.0"
+    "@frontegg/redux-store" "5.54.1"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.54.0":
-  version "5.54.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.54.0.tgz#7064a1f6e6814dad7f4d6d6b7a5817c29614e9a5"
-  integrity sha512-1Pq5ESBY72CeN9YayKdhoi20xuHiR7jHJLYGmiJTaEcGgHhrwEv6r6q85PPeMfX5EJfcHEQ1s1wVQ07T7YLcug==
+"@frontegg/redux-store@5.54.1":
+  version "5.54.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.54.1.tgz#89a0a143ae3475255dff3e15c70ad7074eeb002a"
+  integrity sha512-1omM9YZ0IdnG4DizUFjcVVHo91nxH4oTbAtPn24vMS+2+nVg5kFl23dnjLO5hzeSGnS9CqluwK3jcYgV+9gRLA==
   dependencies:
     "@frontegg/rest-api" "2.10.72"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3023,10 +3023,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.72.tgz#245e263f7d319082aee001239458ade23651145d"
   integrity sha512-5FlIS4W/iUsMTupfo41RF3Pjd/Aq17+7rHe4kV70F992r0iQHpFMg1IVN/pyYtbyhetjRVPQ66zEKNKc5nJmdw==
 
-"@frontegg/types@5.54.0":
-  version "5.54.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.54.0.tgz#a3ba9b19ed02f6d1bdc162cbbf05c95dee42873d"
-  integrity sha512-KQ1kxpPOjnJ+Wpa6xVwd+Gz1RjDvIXzeI7e631ovdMluB13H0bQM6bJs/evvePU9eFnUWHhHUAygVPG8+yK3Pw==
+"@frontegg/types@5.54.1":
+  version "5.54.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.54.1.tgz#c18888fed06c888b415d4b9cb368139a10d8a010"
+  integrity sha512-n9PioED/jiKCPb6T6MUTiKtGc7jD4i7RnY0bG8wfJEEMVsZfy6esctzw7ScV0bc9b16RMziE2rMOi4yhNrPkYQ==
   dependencies:
     csstype "^3.0.9"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,26 +2991,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@5.53.4":
-  version "5.53.4"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.53.4.tgz#8168197c1aa3ed6ce7ceeb4205bb65339e9e0132"
-  integrity sha512-GgEhps4SG6OJxhK+lqLTIzA/+Z0uMSl6PRnG5UVidUzkBR7AH2xNCbiHG+n6Y5AHM8Tw4pM9nuMCq15Quxswhw==
+"@frontegg/admin-portal@5.54.0":
+  version "5.54.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.54.0.tgz#0082987f65e5ebea3ef5c65fe9309f15297d3a22"
+  integrity sha512-EKpU77PGw3o1vQR9SqaWow7Hz+jOs4p42IaQDKXHU33f7/Qe4dB6Y/ya1SmylpPvWLzfu24QACxQj84fj9N1kg==
   dependencies:
-    "@frontegg/types" "5.53.4"
+    "@frontegg/types" "5.54.0"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.53.4":
-  version "5.53.4"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.53.4.tgz#ea8051fc451b6a9e29125901ace47b3ac73296fb"
-  integrity sha512-sry6qma0sMEGNQs7miM9Wd9QU8Vb09axOSC6bOH2Aarap6E/yzQGQblQo+rOeA1NWCVTijd2NSWp3lt2Tb7c0Q==
+"@frontegg/react-hooks@5.54.0":
+  version "5.54.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.54.0.tgz#6ea360cee8656e7ee6ee18b4dfe06ac53b78e88a"
+  integrity sha512-zWEQrJ/dMav0FsdKBhPpBozpJUENtrjb6p/+6BqAob8ogtyEt/WJ6dgdeN/uiLHT8BrgodNZ62yuxPAZEFmCjg==
   dependencies:
-    "@frontegg/redux-store" "5.53.4"
+    "@frontegg/redux-store" "5.54.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.53.4":
-  version "5.53.4"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.53.4.tgz#15a06aa44183d4dbebb576f78cb6cf01a8b6c9bd"
-  integrity sha512-wnuq4UpVZxVdTx7t3xmuScnxvn9LA6/qtaOqSqvJHrPY5AC5/9R0kA0Urb27m79JQ+OrQB5z5CITFLX96bMuFg==
+"@frontegg/redux-store@5.54.0":
+  version "5.54.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.54.0.tgz#7064a1f6e6814dad7f4d6d6b7a5817c29614e9a5"
+  integrity sha512-1Pq5ESBY72CeN9YayKdhoi20xuHiR7jHJLYGmiJTaEcGgHhrwEv6r6q85PPeMfX5EJfcHEQ1s1wVQ07T7YLcug==
   dependencies:
     "@frontegg/rest-api" "2.10.72"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3023,10 +3023,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.72.tgz#245e263f7d319082aee001239458ade23651145d"
   integrity sha512-5FlIS4W/iUsMTupfo41RF3Pjd/Aq17+7rHe4kV70F992r0iQHpFMg1IVN/pyYtbyhetjRVPQ66zEKNKc5nJmdw==
 
-"@frontegg/types@5.53.4":
-  version "5.53.4"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.53.4.tgz#9a220fe0b4393c99b05f227adb0b85e09517e1bd"
-  integrity sha512-W+vOaR7LcDJSyvpeC5Bk2dsA2DnD8ufc71YYRD+K0Uw/N5y4h3c2ZjWBYhppW5uab96vcawcFbHcOnoOPMfo1Q==
+"@frontegg/types@5.54.0":
+  version "5.54.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.54.0.tgz#a3ba9b19ed02f6d1bdc162cbbf05c95dee42873d"
+  integrity sha512-KQ1kxpPOjnJ+Wpa6xVwd+Gz1RjDvIXzeI7e631ovdMluB13H0bQM6bJs/evvePU9eFnUWHhHUAygVPG8+yK3Pw==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.54.1:
- [FR-7813](https://frontegg.atlassian.net/browse/FR-7813) - dummy commit for version - [ff562355](https://github.com/frontegg/admin-box/pulls?q=ff562355)

### AdminPortal 5.54.0:
- [FR-5604](https://frontegg.atlassian.net/browse/FR-5604) - render children if hosted login - [690b9b03](https://github.com/frontegg/admin-box/pulls?q=690b9b03)