### PR TITLE
Update Frontegg AdminPortal to 5.59.1

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir . && echo DONE"
   },
   "dependencies": {
-    "@frontegg/react-hooks": "5.59.0",
+    "@frontegg/react-hooks": "5.59.1",
     "classnames": "^2.2.6",
     "formik": "^2.1.5",
     "history": "^4.9.0",

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.59.0",
-    "@frontegg/react-hooks": "5.59.0"
+    "@frontegg/admin-portal": "5.59.1",
+    "@frontegg/react-hooks": "5.59.1"
   },
   "devDependencies": {
     "next": ">10.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -11,8 +11,8 @@
     "test": "jest --runInBand --passWithNoTests -c ../../scripts/jest.config.json --rootDir ."
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.59.0",
-    "@frontegg/react-hooks": "5.59.0"
+    "@frontegg/admin-portal": "5.59.1",
+    "@frontegg/react-hooks": "5.59.1"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,26 +2991,26 @@
     "@babel/runtime" "^7.10.4"
     react-is "^16.6.3"
 
-"@frontegg/admin-portal@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.59.0.tgz#926eabae86f58437ddef291a4033c0b3687efc0e"
-  integrity sha512-oqzFQZoOW5el8nTk4QKRf2UYlD3UcEDzdIvJJyxUZORQRkLSZDfV4NWmJs7wRqAG+zJBXDUjDl4OzWrB3qg4dw==
+"@frontegg/admin-portal@5.59.1":
+  version "5.59.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.59.1.tgz#8a83783970377096d375a87f95d873d7befe803b"
+  integrity sha512-O6dTF1DiIFr8hIoqL/RG+CFZBsHTqaVfn+XEU27APds9Rb7259yXYHs9WSA1WNq0lS+EW9bQpf154k+PBQz1Xw==
   dependencies:
-    "@frontegg/types" "5.59.0"
+    "@frontegg/types" "5.59.1"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.59.0.tgz#6cb6dc3ca0af7fe270cbf5f79f865d9702cb05db"
-  integrity sha512-M4zlP8A7SCuHYAXkOT7/sH22Oc2S0cAUicXaJA9IS4gQHOl8xCWiEZL4T2CO6Jx67fUSvzRXLY6cgPAjkvCXOg==
+"@frontegg/react-hooks@5.59.1":
+  version "5.59.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.59.1.tgz#3343b07d8983af4a1ce50d73f5125fb1a2826221"
+  integrity sha512-dGEKN3f6bTuSJR9aIp56ZlE6D3n6uZyitHHCqEbYCDsQvW+ArCBH3QdsuUWcNFGA7VPWgitTBqmAeD9DI9/2WQ==
   dependencies:
-    "@frontegg/redux-store" "5.59.0"
+    "@frontegg/redux-store" "5.59.1"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.59.0.tgz#b84e3cf4bcdf8c8aa7d3379370a175d73d02c324"
-  integrity sha512-P+6peBouvIDkBx4FVF08uY/knws4QBdomwokbZjdI8FUnVqggJ6qE1tftIjtuTIgd7cltKbJoFCEOaSYoGPqnw==
+"@frontegg/redux-store@5.59.1":
+  version "5.59.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.59.1.tgz#a7228fa26c2770185a3354dd77aa57f1a9aa9999"
+  integrity sha512-d8addXvVvmHPyDZk1zncbNFNA8mZRzCq2UR0og8LXGBAUPGb8VB/Zh98jRbGmPj12k2IPjQ4WkCiGz96w6LPsA==
   dependencies:
     "@frontegg/rest-api" "2.10.74"
     "@reduxjs/toolkit" "^1.5.0"
@@ -3023,10 +3023,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.74.tgz#1f1a47f888a54778559035a2291c0cf93282308e"
   integrity sha512-g+PN8xUm+TEBop6yshw03u+iHmH68NpAAklQhATAWGgLSGIFPadsHJq7DWZEOWtAhcP69k7rU3Z/gjTQHxnVzg==
 
-"@frontegg/types@5.59.0":
-  version "5.59.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.59.0.tgz#d8b16307c79b821374fa3188d6386a2b4e99811c"
-  integrity sha512-UKbUQO2fmjaTpVMpO6KTLBnhUSN3oQ84ppGAt9H3OaH3zJT4YVgRsgoiSqXGfNf4ufRapJmxEfM9ewxRuXiV0Q==
+"@frontegg/types@5.59.1":
+  version "5.59.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.59.1.tgz#507747a6949ee17b886346f35eb01dc4b2e252e1"
+  integrity sha512-lMj4r4VVWS6bbnP77NvItnE4LrqY6+QfyN7tzazhsbwPMEhec2dikFwTfEw0Ghn/rONTIVDBSRXw1sHGKSDLxA==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.59.1:
- [FR-7231](https://frontegg.atlassian.net/browse/FR-7231) - only one testimonial render - [747d7e5d](https://github.com/frontegg/admin-box/pulls?q=747d7e5d)
- [FR-7231](https://frontegg.atlassian.net/browse/FR-7231) - remove wrap page from child signup components - [d45abd29](https://github.com/frontegg/admin-box/pulls?q=d45abd29)