### PR TITLE
Update Frontegg AdminPortal to 5.66.1

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,8 +10,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.66.0",
-    "@frontegg/react-hooks": "5.66.0"
+    "@frontegg/admin-portal": "5.66.1",
+    "@frontegg/react-hooks": "5.66.1"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1451,26 +1451,26 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@frontegg/admin-portal@5.66.0":
-  version "5.66.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.66.0.tgz#96694345daca9e9bf061da8e9f51053172296c4a"
-  integrity sha512-TEQyIMfs0g0Ac4TM8xABo+2EaFsVUz/ZRrHwJxtY4z/LwkR/qS2EItLqjqanDpIdK3hmk8jzK92m4XD24QhR0w==
+"@frontegg/admin-portal@5.66.1":
+  version "5.66.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.66.1.tgz#dcb01ea14aa18731fff9020930eb56cae0679236"
+  integrity sha512-qGbTkj/PUJXhoeZ5UvBXa/CC6gi6PzXdlOrZYnM35vWE0+ifua8i733m9KhPmPepIMjh9ZGKETB8eyjF3avGsg==
   dependencies:
-    "@frontegg/types" "5.66.0"
+    "@frontegg/types" "5.66.1"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.66.0":
-  version "5.66.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.66.0.tgz#d5b2025c039f7fc044115d9f93d7755acda44d5c"
-  integrity sha512-MLEOSsO6uYcWZ/3kbpWGWNZi+LKKfcaw1GIkIIXRNGQtGHR6v/+Q4X9WsXtwQ6UxHZ+JmxzGvtdRh58+H+kP+A==
+"@frontegg/react-hooks@5.66.1":
+  version "5.66.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.66.1.tgz#5606c935509d75de6e2e5e3f6189a38619f04eb8"
+  integrity sha512-564tzfCmQ9Zw+DVt7Fe7VjBHLTZNfieC0n2CANM/4W9aioaNZLdgmSMJ8nKAV+nTdZtH+RVfhq0aVOou0gc7Bw==
   dependencies:
-    "@frontegg/redux-store" "5.66.0"
+    "@frontegg/redux-store" "5.66.1"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.66.0":
-  version "5.66.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.66.0.tgz#bf63a767c5793d15e2a6941ed7a1f6e832a4b374"
-  integrity sha512-JgF0VfI+tWkik76hEKVwZlYVnxdON+6UgBOxjh5OWP4zcts6Hczy55DtMX/bG4fs9B19X9tcxa3QSKALOHYarA==
+"@frontegg/redux-store@5.66.1":
+  version "5.66.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.66.1.tgz#1891657c3b3708e46801d25a00ddc25d6085c4db"
+  integrity sha512-DVOedXesR6bGKrm0TGPoaqLNH1Y0aBgj7iPwLfuMVjAA9u/JUPmrkCAx/NXgGkwHNDeKn1foVySX2bHmhVbxsg==
   dependencies:
     "@frontegg/rest-api" "^2.10.87"
     "@reduxjs/toolkit" "^1.5.0"
@@ -1483,10 +1483,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.87.tgz#0edfcaf16ef0fc66003d7d4881ffe75f7cc9deec"
   integrity sha512-5lojRJeomz6TssTuy3OHqncUE+K4bThARbszhf3pfxeIvLMk2y1j5WpD3FF+b9F8xlD7dSbMlVuz46JVzwNUpQ==
 
-"@frontegg/types@5.66.0":
-  version "5.66.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.66.0.tgz#2e5eb893cb190a8e741799514228f38c0c7a95d3"
-  integrity sha512-CzjOzQbSV9/UbAxXnYwwSUuaAHCIb7JTpoG47hB3mjxcnAcBHVOWHHuoqIFJaZZ68ZEHHlYJqsBhiLNLA90lng==
+"@frontegg/types@5.66.1":
+  version "5.66.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.66.1.tgz#048ed5288446c989dc911ba3052bf1859d91c595"
+  integrity sha512-XP7YxSWDgN9tjG7QtQCKS6bQoy91B4NDJ//StS/8aPuEQRmOv+TSYvrzGHKCWzWeNRdS7RYU/QAb5Ib6Nqs1gw==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.66.1:
- [FR-8258](https://frontegg.atlassian.net/browse/FR-8258) - skipped webhooks tests to avoid flakyness - [49effd1f](https://github.com/frontegg/admin-box/pulls?q=49effd1f)
- [FR-8246](https://frontegg.atlassian.net/browse/FR-8246) - Fix preview mode bug with all accounts subtitle - [c74073ee](https://github.com/frontegg/admin-box/pulls?q=c74073ee)