### PR TITLE
Update Frontegg AdminPortal to 5.66.2

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,8 +10,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.66.1",
-    "@frontegg/react-hooks": "5.66.1"
+    "@frontegg/admin-portal": "5.66.2",
+    "@frontegg/react-hooks": "5.66.2"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1451,26 +1451,26 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@frontegg/admin-portal@5.66.1":
-  version "5.66.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.66.1.tgz#dcb01ea14aa18731fff9020930eb56cae0679236"
-  integrity sha512-qGbTkj/PUJXhoeZ5UvBXa/CC6gi6PzXdlOrZYnM35vWE0+ifua8i733m9KhPmPepIMjh9ZGKETB8eyjF3avGsg==
+"@frontegg/admin-portal@5.66.2":
+  version "5.66.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.66.2.tgz#0b514ccae4f9bb4646280e905ed21a78a014d082"
+  integrity sha512-+kifIomPcHKlg9V0It5pnuPaqDnigDHbK0W2blkhwbGsU3iVd3CiB+4RqXq/MbB9V2NhgLGpyZhOcdoZHjvxfg==
   dependencies:
-    "@frontegg/types" "5.66.1"
+    "@frontegg/types" "5.66.2"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.66.1":
-  version "5.66.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.66.1.tgz#5606c935509d75de6e2e5e3f6189a38619f04eb8"
-  integrity sha512-564tzfCmQ9Zw+DVt7Fe7VjBHLTZNfieC0n2CANM/4W9aioaNZLdgmSMJ8nKAV+nTdZtH+RVfhq0aVOou0gc7Bw==
+"@frontegg/react-hooks@5.66.2":
+  version "5.66.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.66.2.tgz#74c36de838260a273e6ade355922765a6b491a2f"
+  integrity sha512-QMkSuMR06cHmb8B9DGYwUYRQYdmroiI3u3fx5hYimCLp6kpsZo2gJSXr6Xo90Msz9n7gdwcfTT2ktaQ2ZIHPhw==
   dependencies:
-    "@frontegg/redux-store" "5.66.1"
+    "@frontegg/redux-store" "5.66.2"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.66.1":
-  version "5.66.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.66.1.tgz#1891657c3b3708e46801d25a00ddc25d6085c4db"
-  integrity sha512-DVOedXesR6bGKrm0TGPoaqLNH1Y0aBgj7iPwLfuMVjAA9u/JUPmrkCAx/NXgGkwHNDeKn1foVySX2bHmhVbxsg==
+"@frontegg/redux-store@5.66.2":
+  version "5.66.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.66.2.tgz#f8964696d91274a4ed6ce65df1317ff287470f2a"
+  integrity sha512-uNbPm4ulT03Y6AHRb0Ej5ALSJGyZeZm0KckM+o0Gf3kbpn5C1yD0lYKTksFRHt5JXYu+LQAS/X6RkkUc7xl+5Q==
   dependencies:
     "@frontegg/rest-api" "^2.10.87"
     "@reduxjs/toolkit" "^1.5.0"
@@ -1483,10 +1483,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.87.tgz#0edfcaf16ef0fc66003d7d4881ffe75f7cc9deec"
   integrity sha512-5lojRJeomz6TssTuy3OHqncUE+K4bThARbszhf3pfxeIvLMk2y1j5WpD3FF+b9F8xlD7dSbMlVuz46JVzwNUpQ==
 
-"@frontegg/types@5.66.1":
-  version "5.66.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.66.1.tgz#048ed5288446c989dc911ba3052bf1859d91c595"
-  integrity sha512-XP7YxSWDgN9tjG7QtQCKS6bQoy91B4NDJ//StS/8aPuEQRmOv+TSYvrzGHKCWzWeNRdS7RYU/QAb5Ib6Nqs1gw==
+"@frontegg/types@5.66.2":
+  version "5.66.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.66.2.tgz#1e62bc3afb39867f268e1631dcb3259be7bfb507"
+  integrity sha512-/gMdZduOUP5UsFM/iNDlz9nS0WQAFPLRcFMV4yJsRC47E2vi2VMnrEZU2dDvBHZIaUs7967VdPRO44rBAxhADw==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.66.2:
- [FR-8260](https://frontegg.atlassian.net/browse/FR-8260) - add next js repo to the release pipeline to upgrade admin portal version automatically - [e272ce07](https://github.com/frontegg/admin-box/pulls?q=e272ce07)