### PR TITLE
Update Frontegg AdminPortal to 5.69.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,8 +10,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.68.3",
-    "@frontegg/react-hooks": "5.68.3"
+    "@frontegg/admin-portal": "5.69.0",
+    "@frontegg/react-hooks": "5.69.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1451,26 +1451,26 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@frontegg/admin-portal@5.68.3":
-  version "5.68.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.68.3.tgz#74e4c9d85b0b499c731464791a8579b2acda2aa6"
-  integrity sha512-+iupSVn/oQnyX92+zSf4OfZoHOhbmhzPnyiXrjaysn1T4aoFiStXcXGemLBcWvqHd3UV0ybMZ2xERe37Dw7SRg==
+"@frontegg/admin-portal@5.69.0":
+  version "5.69.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.69.0.tgz#dd40a0d013dc7463c3fb528744408e3e7aa6dbe6"
+  integrity sha512-bqaU6f3aOShn3pW5k5pFodab4p3FE3O0bOul8FhmIC92/rsKBIAusZu277bAWMOTVf/zjGK4PU77oXVzqrMhNg==
   dependencies:
-    "@frontegg/types" "5.68.3"
+    "@frontegg/types" "5.69.0"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.68.3":
-  version "5.68.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.68.3.tgz#2f57a0497e0103e131ea034b5817ea9e97d59577"
-  integrity sha512-VH4dF9hif5Yfakru2BfLpm3NSibGh6OQW5VvoepOHauaAwjzYsQxWKMi8vcCSVqXczmoqXg2Fgbl8jGGGNuNjg==
+"@frontegg/react-hooks@5.69.0":
+  version "5.69.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.69.0.tgz#d728a965a5cfc094c9563c29280a966540d1eaf4"
+  integrity sha512-kGEWkTzmXseG/ivpCgpunx74uYbYLyQFAnHTQTfaDxK0C0zfHCcuASBQTHD8+am3Idp1BDhHBTpe5qkOx3y79Q==
   dependencies:
-    "@frontegg/redux-store" "5.68.3"
+    "@frontegg/redux-store" "5.69.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.68.3":
-  version "5.68.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.68.3.tgz#91613be94506795573bad4b5b36d6ea4caeb3f6c"
-  integrity sha512-BHtrumMcdvrX5KU2malAPPe8R5P7coYmkmlk4ZoMYFvE+gwb21RHXV0ViczAIBVjR2ckJWu0wr8qBrsYqonsQA==
+"@frontegg/redux-store@5.69.0":
+  version "5.69.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.69.0.tgz#7ed356721a27acd48da6092798b75fbb586e0ff6"
+  integrity sha512-NX7/PvBsM226uwwe3QOE5evsOaTYcB/fUrqlMbOzmXA+HO1xIWUIt+XxYxtdomaj8GgfdSOm3yQRnxhYAHYcPg==
   dependencies:
     "@frontegg/rest-api" "^2.10.87"
     "@reduxjs/toolkit" "^1.5.0"
@@ -1483,10 +1483,10 @@
   resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-2.10.87.tgz#0edfcaf16ef0fc66003d7d4881ffe75f7cc9deec"
   integrity sha512-5lojRJeomz6TssTuy3OHqncUE+K4bThARbszhf3pfxeIvLMk2y1j5WpD3FF+b9F8xlD7dSbMlVuz46JVzwNUpQ==
 
-"@frontegg/types@5.68.3":
-  version "5.68.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.68.3.tgz#8a344f76601a5519cc35199ae1f6068a22566f02"
-  integrity sha512-Y70CQezVF1mAzqbNwuH3bahblzZBfAa+VqS56Wwksv6SqBEfk6qbTUc0YxciiyJ1tHn1h1Wem1bkcWVwrleH+Q==
+"@frontegg/types@5.69.0":
+  version "5.69.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.69.0.tgz#c069615dc50093c21494f20c62584795e5df5a56"
+  integrity sha512-ojlq7q5K3RG20CgGf+XAf1iePWjkhyhbSRng9jOKE6ajitbtxkX6EDENqQNJNnTuJpe3Y8uFy7Hy50K/xDnytg==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.69.0:
- [FR-8377](https://frontegg.atlassian.net/browse/FR-8377) - fix mfa bug on speedy login - [1ea01020](https://github.com/frontegg/admin-box/pulls?q=1ea01020)
- [FR-8363](https://frontegg.atlassian.net/browse/FR-8363) - Fix cypress removing videos - [6ec7e647](https://github.com/frontegg/admin-box/pulls?q=6ec7e647)