### PR TITLE
Update Frontegg AdminPortal to 5.75.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,8 +10,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/admin-portal": "5.74.1",
-    "@frontegg/react-hooks": "5.74.1"
+    "@frontegg/admin-portal": "5.75.0",
+    "@frontegg/react-hooks": "5.75.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1458,26 +1458,26 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@frontegg/admin-portal@5.74.1":
-  version "5.74.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.74.1.tgz#cf8fb7ca5695b16b322749904670abce8bfee63a"
-  integrity sha512-pK8hfuf9jSmDZa3u4JvGxhrAf2rKRdJB4lBOgDebKEk4o8maIQ99zEEU30GD0OLE+hWfr+Uit9vdut5NKVBTAQ==
+"@frontegg/admin-portal@5.75.0":
+  version "5.75.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/admin-portal/-/admin-portal-5.75.0.tgz#b3aacd6bb7d9f6eaecc10ca35aa71328eb570d1c"
+  integrity sha512-QzTbcB3JnBdldIar+5NxJPy/mz033bLUZINO8/ruFHUev8RDUEoW5/ar2YlRRqHqQr0937Xcb8ZiqcUMMY3euQ==
   dependencies:
-    "@frontegg/types" "5.74.1"
+    "@frontegg/types" "5.75.0"
     uuid "^8.3.2"
 
-"@frontegg/react-hooks@5.74.1":
-  version "5.74.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.74.1.tgz#9905a8a5a2336f7f9e4c62e65ca2ad96ab2173b5"
-  integrity sha512-zpTMtrl9sQCqLiWTgX56bQ8SGYb0K/YzimxPnuMhQqj+ZTfhizK5ZETF7bvYZVi4oqrJH5ux/cW+iMMPfwTJ4A==
+"@frontegg/react-hooks@5.75.0":
+  version "5.75.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-5.75.0.tgz#2edc2b035a6f7ff331df2808ea56d419a5bf7ec3"
+  integrity sha512-ilUucRiJ24qRNEPQ81rZFFDWq5xuvMkffuV+Y5seEhMKOqKWvuZi7vSd+3nWf/qCVpMR4vpbPcrF04Khcglpuw==
   dependencies:
-    "@frontegg/redux-store" "5.74.1"
+    "@frontegg/redux-store" "5.75.0"
     react-redux "^7.x"
 
-"@frontegg/redux-store@5.74.1":
-  version "5.74.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.74.1.tgz#053e9acd366af95bb418cc34e7337c705ba8cc68"
-  integrity sha512-Cvfd5jq81Kgr8JuU4MJv7cfA1rL5HNPm+3uX8V5zdsb2w0eppKEyv6UaZ2HrMZ3oMQj3B7BoFjG/pqqR5BqK7A==
+"@frontegg/redux-store@5.75.0":
+  version "5.75.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-5.75.0.tgz#725b8453c74866e59c83a0a9515340cea6021624"
+  integrity sha512-Lum3UlAvM/jCOZzDjZsbw+Hmo9zsdpOKCUSs8HwEMTCs7T889JKRJxn6XcqljHTyCGb7Hg1xdEDuWN2p8cfJEQ==
   dependencies:
     "@frontegg/rest-api" "^3.0.10"
     "@reduxjs/toolkit" "^1.5.0"
@@ -1492,10 +1492,10 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@5.74.1":
-  version "5.74.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.74.1.tgz#5782bf851aae250797130bd6bea15ef020183a1a"
-  integrity sha512-e0THoWjjnyzP+8KU8VDzBlet5tZk8Sn0ZDTwjzNerjzWMA1YNoubgtmRxE74LrGCRKus1BjBNb/EWxeyCajzSA==
+"@frontegg/types@5.75.0":
+  version "5.75.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-5.75.0.tgz#47a405c731139f44bab986c8692cc2b3b2291fc7"
+  integrity sha512-lTDF7H/nnhVW1FGiaipJ+DlWTcswWhpej86OiLr55qJ0vgJyjiQ5dZYFdVKF57sYGAiIL2G75+9s+5tlypMpGA==
   dependencies:
     csstype "^3.0.9"
 


### PR DESCRIPTION
### AdminPortal 5.75.0:
- [FR-8562](https://frontegg.atlassian.net/browse/FR-8562) - Bump eventsource from 1.0.7 to 1.1.2 - [d356308c](https://github.com/frontegg/admin-box/pulls?q=d356308c)