### PR TITLE
Update Frontegg AdminPortal to 6.2.4

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,8 +10,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "6.2.3",
-    "@frontegg/react-hooks": "6.2.3"
+    "@frontegg/js": "6.2.4",
+    "@frontegg/react-hooks": "6.2.4"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1458,29 +1458,29 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@frontegg/js@6.2.3":
-  version "6.2.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.2.3.tgz#9d6f07f6fa8689751b8fde338f4e83421b87c4d4"
-  integrity sha512-KAwUYRLqkov5+1j5+xkdr5TREa+Buf2PhEfCaN8eviAINwtFY0pFkTlc20gUDI1cN7rk/iycddfwN+GO3vcPyA==
+"@frontegg/js@6.2.4":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.2.4.tgz#b46ac4b10d0035c019142c2f73c240d0f765ec0e"
+  integrity sha512-HWhnZ8MS4rYGy2W7mqlXTC1LEqMYrRaWMfmmi018Do1tLx5WnCdNoKnIL5xiP3yFoZMgQt7a7NYklJEMkP1NsA==
   dependencies:
     "@babel/runtime" "^7.17.2"
-    "@frontegg/types" "6.2.3"
+    "@frontegg/types" "6.2.4"
 
-"@frontegg/react-hooks@6.2.3":
-  version "6.2.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.2.3.tgz#515c2712173b3c74ae59a40bf599de2a4ae888d1"
-  integrity sha512-MyBBTcm3502g5K36NJ+Pw0YkfmX4Ag1P0Ex6Gby/3HRLPY6AA9ylRyQe1cCkBZQwzNPsRjYoC1fwUZ+M7vWmFA==
+"@frontegg/react-hooks@6.2.4":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.2.4.tgz#e4a3f9a1269ad5aa550cd3c5968709aeb73242ec"
+  integrity sha512-wyVH+2GG2JV0TmQ3OJKj04Ja+EnJfuJkb5KIQEct/bSfzsyfmWPthPFUq1OQqLP/GTerz7cOwsArBduuqsKGwA==
   dependencies:
     "@babel/runtime" "^7.17.2"
-    "@frontegg/redux-store" "6.2.3"
-    "@frontegg/types" "6.2.3"
+    "@frontegg/redux-store" "6.2.4"
+    "@frontegg/types" "6.2.4"
     "@types/react" "*"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.2.3":
-  version "6.2.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.2.3.tgz#7c554b1b2be965868b4b248beb3722b821b62f0e"
-  integrity sha512-vzjsm+MK6Qo/V5R6TgWGPz8OgLgpYCvESxztALOvsJkRYDyMhZJuboJyFNUQb+2Qeo3YRhAsDikgHoPNd0YkJw==
+"@frontegg/redux-store@6.2.4":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.2.4.tgz#0f3d6ddf07e572c484cba6a2ff93f991d3a21e44"
+  integrity sha512-ELn3K+RxQFW00Fotk3ICxriHdBm1RZccSUCc19BMrkCJJjcjy+g1774GAhDE761ZIQTnwP+HTyFvzBQFtAD6Fw==
   dependencies:
     "@babel/runtime" "^7.17.2"
     "@frontegg/rest-api" "3.0.11"
@@ -1495,13 +1495,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.2.3":
-  version "6.2.3"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.2.3.tgz#fa1bc5449f30fb3238b532148a2d68345db915e0"
-  integrity sha512-A9OtBZzX2hkEz1AuRLrQMM1rHAz+LJGLRHX1gixjyi8BteOBdScwu5ziGU/pJ1iDNykXTvdZqXp/38I0BQwe/Q==
+"@frontegg/types@6.2.4":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.2.4.tgz#40a65d9aa8d611d4adb934980774d1983ef1774c"
+  integrity sha512-9D00JVoVSpqX7rpBNd3zakhKX/9AH8JG1qALIpp8BVzfHouwZV1zMHZTdCEKhJGvvgXPDI+FWozQ/gEuX+7enQ==
   dependencies:
     "@babel/runtime" "^7.17.2"
-    "@frontegg/redux-store" "6.2.3"
+    "@frontegg/redux-store" "6.2.4"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
### AdminPortal 6.2.4:
- [FR-8882](https://frontegg.atlassian.net/browse/FR-8882) - Make sure to show touch id in speedy login on the builder preview for all users - [eb36dc64](https://github.com/frontegg/admin-box/pulls?q=eb36dc64)
- [FR-8956](https://frontegg.atlassian.net/browse/FR-8956) - fix user management permissions - [417ed973](https://github.com/frontegg/admin-box/pulls?q=417ed973)