### PR TITLE
Update Frontegg AdminPortal to 6.4.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,8 +10,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "6.3.0",
-    "@frontegg/react-hooks": "6.3.0"
+    "@frontegg/js": "6.4.0",
+    "@frontegg/react-hooks": "6.4.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1257,6 +1257,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.18.6":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
+  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
@@ -1458,50 +1465,50 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@frontegg/js@6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.3.0.tgz#fc94ffa5df3940d24c86b55612b93f0f75f246d5"
-  integrity sha512-HvGyv8uunmipeEwwEMP3c1OS9Hm+WyjrCgANVEsbadlLTaBVofKivonJlg6CSDYdgiZnmpJs4ZzctnMLt8OCvg==
+"@frontegg/js@6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.4.0.tgz#779e9647c9728bc80dc6df2be1ca37e68c0cf5ef"
+  integrity sha512-mxEj8WWOADiEz806wpGnpwXqFnFYVnzQSVukqK27pmEgVZqNic0DHqi0y2c0PYdyxgZHq4QNcA5t6pDSIueA9Q==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@frontegg/types" "6.3.0"
+    "@babel/runtime" "^7.18.6"
+    "@frontegg/types" "6.4.0"
 
-"@frontegg/react-hooks@6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.3.0.tgz#14dd8e79dc8528c121a77ffc79048cb9b9399de7"
-  integrity sha512-RebPsHWJ2bAN5uS/KcZR3i8ukHNpCbBz9uweeaApswtp42aMbxzgqPLDkBhVILWKDuYD0XpX5j8Bu0ZG29OWAQ==
+"@frontegg/react-hooks@6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.4.0.tgz#f6d3383e006fa1487fa44aa329d1cb26ce0c13ea"
+  integrity sha512-p5rstTdMw64qDp/naRKanIFeCjcF88bJjqC5HEm1r9oC6WRziRMmxY+UHezyLZChDg49CcQYGV8r+5R1XPmrNA==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@frontegg/redux-store" "6.3.0"
-    "@frontegg/types" "6.3.0"
+    "@babel/runtime" "^7.18.6"
+    "@frontegg/redux-store" "6.4.0"
+    "@frontegg/types" "6.4.0"
     "@types/react" "*"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.3.0.tgz#31df418e647654160c44e9584729fe72286c370f"
-  integrity sha512-wiScdbkHs1GJsdUX1jKRjiRagDIndp98jlomwMG5YDufhVYYxjNJmYPtqJ9K1yyDct30ihSsoDNWTQ/62Z+qIw==
+"@frontegg/redux-store@6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.4.0.tgz#f06fa059d0f2edd635eff3fb92941b4147ea4cc6"
+  integrity sha512-c09BI/qU7T+qTh3tc4SC9VepIUpPOAX67G0++NGAs5iD8z4MsUD1zeKPZEgSGh8qatLydKgZJM8HjV+9oZtvvw==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@frontegg/rest-api" "3.0.11"
-    "@reduxjs/toolkit" "^1.8.3"
-    redux-saga "^1.1.3"
+    "@babel/runtime" "^7.18.6"
+    "@frontegg/rest-api" "3.0.24"
+    "@reduxjs/toolkit" "^1.8.5"
+    redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@3.0.11":
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.11.tgz#69aa672cc4e745985e78a5067239d91068ac5a21"
-  integrity sha512-GHFG8fNvpP0uYxJvpj1ZKN4qyCqPf8hnkcoSmdebttNqXv2j+/I8iNeDGrDUlflNoWMFImq0Lw6wTGy3Y+4Pbw==
+"@frontegg/rest-api@3.0.24":
+  version "3.0.24"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.24.tgz#96fb2abbd0db506e202d0c17ce3455f10c6923ab"
+  integrity sha512-I0bJyFCu/4ij8BDFmzmef+R8YO12GpfxJyTfKHBhe7+DMwBQXBjruON2jwmlWtv4Xz2DNRmjct5pr2IivDjngQ==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.3.0.tgz#b4f32e46892cf9dbfad90d9964b4bed84999996b"
-  integrity sha512-VDkqeTNlXjD4qNAtQ207tvMyU/aOo5l9Bz5kPi7LpTSnksT3B7Ele6qLG+qNsMgHq1aYUzp788yOT6I4ZSCz0Q==
+"@frontegg/types@6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.4.0.tgz#60b46bba362396f34ed5a0abe661573c602710a6"
+  integrity sha512-rvNrd4q9nyMoX2nPv72bnz9ku2b/hzhQHy6ePNTWu39qHLonPwqrwcw4WZTyrkoUokSNfTOn4IRtuyP+v1r+Uw==
   dependencies:
-    "@babel/runtime" "^7.17.2"
-    "@frontegg/redux-store" "6.3.0"
+    "@babel/runtime" "^7.18.6"
+    "@frontegg/redux-store" "6.4.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 
@@ -2852,7 +2859,7 @@
   resolved "https://registry.yarnpkg.com/@redux-saga/types/-/types-1.2.1.tgz#9403f51c17cae37edf870c6bc0c81c1ece5ccef8"
   integrity sha512-1dgmkh+3so0+LlBWRhGA33ua4MYr7tUOj+a9Si28vUi0IUFNbff1T3sgpeDJI/LaC75bBYnQ0A3wXjn0OrRNBA==
 
-"@reduxjs/toolkit@^1.8.3":
+"@reduxjs/toolkit@^1.8.5":
   version "1.8.5"
   resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.8.5.tgz#c14bece03ee08be88467f22dc0ecf9cf875527cd"
   integrity sha512-f4D5EXO7A7Xq35T0zRbWq5kJQyXzzscnHKmjnu2+37B3rwHU6mX9PYlbfXdnxcY6P/7zfmjhgan0Z+yuOfeBmA==
@@ -12423,7 +12430,7 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
-redux-saga@^1.1.3:
+redux-saga@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-1.2.1.tgz#3d730563c8d980525fa5e333ea1ee6e143452275"
   integrity sha512-fVCicLlf4hLP+KB6H7RHfZlZ8LdYckhaemXBB3wh//a2ESyz/z/l8ygxlm0OqPjS/PARdsQ2hIdAltxEB+NgvA==


### PR DESCRIPTION
### AdminPortal 6.4.0:
- [FR-8921](https://frontegg.atlassian.net/browse/FR-8921) - test plan for login box - [cc128ca1](https://github.com/frontegg/admin-box/pulls?q=cc128ca1)
- [FR-7615](https://frontegg.atlassian.net/browse/FR-7615) - Fix Permissions for viewing API tokens - [d5cc58dd](https://github.com/frontegg/admin-box/pulls?q=d5cc58dd)