### PR TITLE
Update Frontegg AdminPortal to 6.6.1

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,8 +10,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "6.6.0",
-    "@frontegg/react-hooks": "6.6.0"
+    "@frontegg/js": "6.6.1",
+    "@frontegg/react-hooks": "6.6.1"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1465,29 +1465,29 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@frontegg/js@6.6.0":
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.6.0.tgz#f2517fda524a3c56df742fe48f5b52f68e4e353d"
-  integrity sha512-RsnonFO+sx2F6ANRTKf/SP7WOKaHd1tlBjRqpC1fa/Pvzuvv73+vAUNtpbY6lihJVNQVpt+R4keadDXXEa9P0w==
+"@frontegg/js@6.6.1":
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.6.1.tgz#8d9f22472aa39720f89acdaa1c0cb242448d7bd4"
+  integrity sha512-RbXJafRnumCgg+qe/gJPLBofzwNNoaM4yf/HZ4gdIP0R5+4cXhTSIk7qTVkXythei0JLOxrkFNs9etKTNPEZNQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.6.0"
+    "@frontegg/types" "6.6.1"
 
-"@frontegg/react-hooks@6.6.0":
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.6.0.tgz#7beb24977df3761dad817430ff09fc38fc3b4d9f"
-  integrity sha512-oGbU0Z2uTtkRBGKzKi9qpP8G6GX3m0HPUUW4pMfsDkujbnSv3J/12CRvfkgHd3cuuE+FAGQB2tJLxMv2rEt9yw==
+"@frontegg/react-hooks@6.6.1":
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.6.1.tgz#ae38473305ec482940501c504587a129fdc04b64"
+  integrity sha512-hEscP9yZDlWIr+d/H2uP9hvUSjyXPBXbt7lxaQbDhDN1MZEerFuISnZb9KYHQdK18keRFJvQUkFne9Jh+9mx3Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.6.0"
-    "@frontegg/types" "6.6.0"
+    "@frontegg/redux-store" "6.6.1"
+    "@frontegg/types" "6.6.1"
     "@types/react" "*"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.6.0":
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.6.0.tgz#24309ea1c4de4abe7691b02e5331ca6be26830cf"
-  integrity sha512-DDDcV0uCgB2P/A0e8Vh8OB4zTpBVJyPMKdTuLF3XH1DUvA9p/s8VYomBVbilPRSXfUM64D1QxWdZuAGmnleZFA==
+"@frontegg/redux-store@6.6.1":
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.6.1.tgz#6dd1a3adf484d8fe227c965ab6257b6966cd9082"
+  integrity sha512-WlkzUNFKFXynLg83VPUtOZuHntubpVYeHOlB9c69G2+sHnuIoyNNsTWIYQIS3tjpv7MdSN9/rOUBsbeMx28dTg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/rest-api" "3.0.25"
@@ -1502,13 +1502,13 @@
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.6.0":
-  version "6.6.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.6.0.tgz#1eacbb4c41cc792b6493d1bf2d6c6808c3b6307d"
-  integrity sha512-MYeOblQNJD5z73lIuATIuigbN+kvTBoCEFpNPil2kwLRz7zbLghFtPGRgofBTr5AzfNtJ634Nh+FEYczIk7vnA==
+"@frontegg/types@6.6.1":
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.6.1.tgz#5e94809c61031e6efd7ea5843b48f5206329c41a"
+  integrity sha512-XpHVrrmSBIeOpJlVqYZeHeu6b/8Slkm0VmoOtvaXOIyzfiA6lc5VXXKjhZj0sZ7SaDoarq6NDMOhCavD6Xg9tg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.6.0"
+    "@frontegg/redux-store" "6.6.1"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
### AdminPortal 6.6.1:
- [FR-9085](https://frontegg.atlassian.net/browse/FR-9085) - fix hash routing - [01b308ef](https://github.com/frontegg/admin-box/pulls?q=01b308ef)