### PR TITLE
Update Frontegg AdminPortal to 6.49.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,8 +10,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "6.48.0",
-    "@frontegg/react-hooks": "6.48.0"
+    "@frontegg/js": "6.49.0",
+    "@frontegg/react-hooks": "6.49.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1465,50 +1465,50 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@frontegg/js@6.48.0":
-  version "6.48.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.48.0.tgz#362b869de07d4eaa1fa8b72fc9d3c5269b5b6764"
-  integrity sha512-FtQ87zh8Vk6kDtN8OaninVaTe5sGiVVLU8KdSQpSaSBncOlKx3MoGaYdenmGC/cauj8PXJo/xiJ0zkrfFfcSrg==
+"@frontegg/js@6.49.0":
+  version "6.49.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.49.0.tgz#4f7a08196f434dd4d88b9458957f5f1c77afa5be"
+  integrity sha512-2vTpB1BZohQ2b0q8sAUGpqCFKogA4/gIv/jlxh0wJai9ITfJitEzXaHYWIkNpqtXwhiIs+w9Iedr4qYAF8li7w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.48.0"
+    "@frontegg/types" "6.49.0"
 
-"@frontegg/react-hooks@6.48.0":
-  version "6.48.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.48.0.tgz#1ec30d5aeb04812de34f43f94239f3a5e8f8cfca"
-  integrity sha512-eSpxaTmuDmp51NZZyZ14FfKWq3Wk1h+F2fgTzqvhij2S3J9+zkNijsdT+rEaANBwZZYHrYLepntVgWnLeyIiCw==
+"@frontegg/react-hooks@6.49.0":
+  version "6.49.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.49.0.tgz#2ecb49ee8b48ae0e34ef1de948ee9ed762e5c26c"
+  integrity sha512-55ffCZ+oEGf0dUEW4au8o0rArimj6lkSMBxih25IHRP4SpEcfk5oLciAz3Ya3fJ8/LJVrdKODnvnxMpy9ogUzw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.48.0"
-    "@frontegg/types" "6.48.0"
+    "@frontegg/redux-store" "6.49.0"
+    "@frontegg/types" "6.49.0"
     "@types/react" "*"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.48.0":
-  version "6.48.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.48.0.tgz#5ded93f776ab8e69d34a6cd6fe73974fb3a0d419"
-  integrity sha512-LIBqnWW3Bk+9rQpvGD24eCGr77cXAaoH/6xJbRfnPg6ut4PrkmARC3dymx0KFsyFbwgn4V5UPoUykZKVR6UtBA==
+"@frontegg/redux-store@6.49.0":
+  version "6.49.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.49.0.tgz#a708d86262c4fafe5a860d03e9707a5bb9cad258"
+  integrity sha512-T2dH6JMj8d0wSE02tzHSsueqHeEN3mD8OoxnTmUK18F75pZGSUwj8wpEgswhuYHLDsaPAnbUWPfTRSa1KjFWmw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "^3.0.43"
+    "@frontegg/rest-api" "^3.0.48"
     "@reduxjs/toolkit" "^1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@^3.0.43":
-  version "3.0.44"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.44.tgz#346e1d7d6cf201cbe19ec71946f66ab1d8d9bb06"
-  integrity sha512-E543LThsZy3q7UTqPqBVcHuKowU0ux9RmZyNsIgIPrZpGcHvygpLXwtEj+/n1v67fiEyE/tiLQlHVSpiaGwyjA==
+"@frontegg/rest-api@^3.0.48":
+  version "3.0.48"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.48.tgz#0691273b328e79fa624c9a46d8a42a41b87d0c73"
+  integrity sha512-SpWmgEoSwwXJi0kWpPM9saOBpDFEolLRzApuNHlNRU6AZ2Xoufry1TsCqhJpQVYpNgzmrzHR9k4w2xi+7ZG83w==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.48.0":
-  version "6.48.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.48.0.tgz#ff131811ca39e4b13bb5f91f344910e8013692b3"
-  integrity sha512-Kcyj1kvT+wvMNmug7zF4p+mueIKwnF5lhZUMLwxCw0cZwaW/uRR3aqbaYi1IlZ000f3UCbsKh2/HkPL/a5y5KA==
+"@frontegg/types@6.49.0":
+  version "6.49.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.49.0.tgz#456a59605e356c9dcd2c93ca8c435b03f7b9b4aa"
+  integrity sha512-XGpzpKcI+u6+kVe5WFERbk23k7mBtQdAcAmvet8468ge9FeDx8stIY/zqGLwxtgPZazmvWyHHOjPmEhYH1XdQw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.48.0"
+    "@frontegg/redux-store" "6.49.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-9914 - Move initial api calls to NextJS server-side before the first render
- FR-9887 - OTC digits are not visible on mobile devices
- FR-9860 - mfa devices management
- FR-9418 - invite email bulk