### PR TITLE
Export AppHolder

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,7 +2,7 @@ export * from './FronteggProvider';
 export * from './AuthorizedContent';
 export * from './CheckoutDialog';
 
-export { AdminPortal, CheckoutDialog } from '@frontegg/js';
+export { AdminPortal, CheckoutDialog, AppHolder } from '@frontegg/js';
 export * from '@frontegg/react-hooks';
 export * from '@frontegg/types';
 export { ContextHolder } from '@frontegg/rest-api';


### PR DESCRIPTION
This change also requires modifying `@frontegg/js`:
```patch
diff --git a/node_modules/@frontegg/react/index.js b/node_modules/@frontegg/react/index.js
index d2199a7..abfb09d 100644
--- a/node_modules/@frontegg/react/index.js
+++ b/node_modules/@frontegg/react/index.js
@@ -239,4 +239,5 @@ exports.Connector = Connector;
 exports.ConnectorHistory = ConnectorHistory;
 exports.FronteggProvider = FronteggProvider;
 exports.useCheckoutDialog = useCheckoutDialog;
+exports.AppHolder = AppHolder.AppHolder;
 //# sourceMappingURL=index.js.map
```

Where can I modify it?