### PR TITLE
Update Frontegg AdminPortal to 6.52.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,8 +10,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "6.51.0",
-    "@frontegg/react-hooks": "6.51.0"
+    "@frontegg/js": "6.52.0",
+    "@frontegg/react-hooks": "6.52.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1465,50 +1465,50 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@frontegg/js@6.51.0":
-  version "6.51.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.51.0.tgz#8ec9fa1362a052da832184e1be71bbb5e28a31dc"
-  integrity sha512-TZG7gJ0K19U+OImG0zOzoEGKylnlxjb9dNC7bYuTmdLSLPZkV8TEDJgZ9pi1TK2A5cypUGm8V1bgxaelpl+djg==
+"@frontegg/js@6.52.0":
+  version "6.52.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.52.0.tgz#aeef1905699fe6eeca918e7731f565c799818222"
+  integrity sha512-ZQ10GAFRPbj1o5mEPXrsp4k/QjszXLS4uUwJKEtVc6eFwD0slGUQ2XHW6FW9WhG2klgnphdD5qWHVvvl1g31QA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.51.0"
+    "@frontegg/types" "6.52.0"
 
-"@frontegg/react-hooks@6.51.0":
-  version "6.51.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.51.0.tgz#80829bc75a1a141b309bc72ab230203b04713784"
-  integrity sha512-Vt5PmnSo7BV5DWgdvCxmLzmGzs+ajSMJU6ki/i6C/U4dHIBbG8ssYy1SAlGP6noZnDVwzulNUqXuq7D2KmXIOg==
+"@frontegg/react-hooks@6.52.0":
+  version "6.52.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.52.0.tgz#5e5e4ce171e103d28ad5b9870ad86698f3f45b3a"
+  integrity sha512-gdKx4WATsjkZFIrVLGNUTKiM4AXK6DYdC5AJiKHpsDX1pJc3UbXx7FodIYymUWHrfueRQnXvFreTwxRXH8j25A==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.51.0"
-    "@frontegg/types" "6.51.0"
+    "@frontegg/redux-store" "6.52.0"
+    "@frontegg/types" "6.52.0"
     "@types/react" "*"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.51.0":
-  version "6.51.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.51.0.tgz#2db880140d93a28b44c64f236c65d0ab74b73041"
-  integrity sha512-SGLGOpxbmhMDOD5mzA8LDISxkLZethzxePlMhCmpBDTQsAzDnb2NZHYmz6tpUU99wM9JruI9P/jL4hH22VQFiw==
+"@frontegg/redux-store@6.52.0":
+  version "6.52.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.52.0.tgz#067dbb842e7711c8d11f95f5553384658a6a88b5"
+  integrity sha512-QqWGS0dLaUua5AiVKAUFWw4FJIsQ30M22UmHAMKlLEYf96FM/71o9gk+ZKFp8sNMzQOVpDyrXP5eaM0+M0ESNA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/rest-api" "^3.0.51"
+    "@frontegg/rest-api" "^3.0.52"
     "@reduxjs/toolkit" "^1.8.5"
     redux-saga "^1.2.1"
     uuid "^8.3.2"
 
-"@frontegg/rest-api@^3.0.51":
-  version "3.0.51"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.51.tgz#b8c9c822f0a6a74904384ac4ca3d178ff9bac732"
-  integrity sha512-2gf2lK+RjNxnOEGq/5CwDz2kdtV07sQlwJtjMCHBjrPdM5YvujhHyHnxqTRid25R6X8ILXLbYN6qu0bk+woUIw==
+"@frontegg/rest-api@^3.0.52":
+  version "3.0.52"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-3.0.52.tgz#c29baed132eeab9110c8b28a6cebf8dd425b2737"
+  integrity sha512-Ne3gnDEhN3EkYPrNqHBaIc/ETrd2N/AeP/xYq5+usLlAbCCjMgjTBHZGYCh9HChhKb0P6xhzfFf19Q1LwL2mDg==
   dependencies:
     "@babel/runtime" "^7.17.2"
 
-"@frontegg/types@6.51.0":
-  version "6.51.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.51.0.tgz#e13d8c13d359924a1473ad7035434ff448e22c90"
-  integrity sha512-W3wcF3bgRoGGPsuRVnem4hsuC0GSMhi70QP4TlFphpt/e6tPIrQlHo+KSlImH2RNTfZn6/RhoqeozkQDZjBTzA==
+"@frontegg/types@6.52.0":
+  version "6.52.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.52.0.tgz#c72ec6ef8e63011023684ebb5aedac9f5c5095f7"
+  integrity sha512-WMH582Q4E6Ct4Th8UHkL5QFjVgmhAbjREZ9/ghyxX/hT7TlgdPMaA03CkOe6AVYjGRlwt2XaU+URvi12wOzE0w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.51.0"
+    "@frontegg/redux-store" "6.52.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-10024 - fix bulk
- FR-10072 - mobile fixes for mfa
- FR-9821 - enable scim without roles
- FR-10010 - mfa fixes
- FR-10028 - fix menu for dark
- FR-10010 - card list item on click fix
- FR-10020 - add api navigation icon
- FR-10016 - mfa tests
- FR-9731 - add apple social login types
- FR-9936 - Hide Invoices on FronteggAppOptions