### PR TITLE
FR-13417 - Fixed include query param after signup

### DIFF
--- a/packages/react/rollup.config.js
+++ b/packages/react/rollup.config.js
@@ -51,6 +51,7 @@ const cjsPlugins = [
 const isExternal = (id) => {
   return (
     id !== './FronteggProvider' &&
+    id !== './AlwaysRenderInProvider' &&
     id !== './AuthorizedContent' &&
     id !== './sdkVersion' &&
     id !== './routerProxy' &&

--- a/packages/react/src/AlwaysRenderInProvider.tsx
+++ b/packages/react/src/AlwaysRenderInProvider.tsx
@@ -1,0 +1,41 @@
+import React, { FC } from 'react';
+import { useAuthRoutes, CustomComponentRegister } from '@frontegg/react-hooks';
+import { useQueryKeeper } from './queryKeeper';
+import { FronteggApp } from '@frontegg/js';
+import { FronteggThemeOptions } from '@frontegg/types';
+
+export type HistoryObject = {
+  push: (path: string) => void;
+  replace: (path: string) => void;
+};
+
+type QueryKeeperWrapperProps = {
+  history: HistoryObject;
+};
+
+export const QueryKeeperWrapper: FC<QueryKeeperWrapperProps> = ({ history }) => {
+  const { signUpUrl } = useAuthRoutes();
+  useQueryKeeper({ routes: { signUpUrl }, history });
+  return <></>;
+};
+
+type AlwaysRenderInProviderProps = {
+  isExternalHistory: boolean;
+  app: FronteggApp;
+  themeOptions?: FronteggThemeOptions;
+  history: HistoryObject;
+};
+
+export const AlwaysRenderInProvider = ({
+  isExternalHistory,
+  app,
+  themeOptions,
+  history,
+}: AlwaysRenderInProviderProps) => {
+  return (
+    <>
+      <CustomComponentRegister app={app} themeOptions={themeOptions} />
+      {!isExternalHistory && <QueryKeeperWrapper history={history} />}
+    </>
+  );
+};

--- a/packages/react/src/FronteggProvider.tsx
+++ b/packages/react/src/FronteggProvider.tsx
@@ -1,14 +1,14 @@
 import React, { FC, ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
 import { initialize } from '@frontegg/js';
 import { FronteggAppOptions } from '@frontegg/types';
-import { FronteggStoreProvider, useAuthRoutes, CustomComponentRegister } from '@frontegg/react-hooks';
+import { FronteggStoreProvider } from '@frontegg/react-hooks';
 import { BrowserRouter, useHistory, UseHistory } from './routerProxy';
 import { ContextHolder, RedirectOptions, FronteggFrameworks } from '@frontegg/rest-api';
 import { AppHolder } from '@frontegg/js/AppHolder';
-import { useQueryKeeper } from './queryKeeper';
 import { isAuthRoute } from '@frontegg/redux-store';
 import sdkVersion from './sdkVersion';
 import ReactPkg from 'react/package.json';
+import { AlwaysRenderInProvider, HistoryObject } from './AlwaysRenderInProvider';
 
 export type FronteggProviderProps = FronteggAppOptions & {
   appName?: string;
@@ -16,29 +16,14 @@ export type FronteggProviderProps = FronteggAppOptions & {
   children?: ReactNode;
 };
 
-type HistoryObject = {
-  push: (path: string) => void;
-  replace: (path: string) => void;
-};
-
 type ConnectorProps = Omit<FronteggProviderProps, 'history'> & {
   history: HistoryObject;
   isExternalHistory?: boolean;
 };
 
-type QueryKeeperWrapperProps = {
-  history: HistoryObject;
-};
-
 export const ConnectorHistory: FC<Omit<ConnectorProps, 'history'>> = (props) => {
   const history = useHistory();
   return <Connector history={history} {...props} />;
-};
-
-export const QueryKeeperWrapper: FC<QueryKeeperWrapperProps> = ({ history }) => {
-  const { signUpUrl } = useAuthRoutes();
-  useQueryKeeper({ routes: { signUpUrl }, history });
-  return <></>;
 };
 
 export const Connector: FC<ConnectorProps> = ({ history, appName, isExternalHistory = false, ...props }) => {
@@ -100,10 +85,12 @@ export const Connector: FC<ConnectorProps> = ({ history, appName, isExternalHist
     <FronteggStoreProvider
       {...({ ...props, app } as any)}
       alwaysVisibleChildren={
-        <>
-          <CustomComponentRegister app={app} themeOptions={props.themeOptions} />
-          {!isExternalHistory && <QueryKeeperWrapper history={history} />}
-        </>
+        <AlwaysRenderInProvider
+          app={app}
+          themeOptions={props.themeOptions}
+          history={history}
+          isExternalHistory={isExternalHistory}
+        />
       }
     />
   );

--- a/packages/react/src/FronteggProvider.tsx
+++ b/packages/react/src/FronteggProvider.tsx
@@ -8,7 +8,7 @@ import { AppHolder } from '@frontegg/js/AppHolder';
 import { useQueryKeeper } from './queryKeeper';
 import { isAuthRoute } from '@frontegg/redux-store';
 import sdkVersion from './sdkVersion';
-import ReactPkg from 'react/package.json'
+import ReactPkg from 'react/package.json';
 
 export type FronteggProviderProps = FronteggAppOptions & {
   appName?: string;
@@ -99,7 +99,12 @@ export const Connector: FC<ConnectorProps> = ({ history, appName, isExternalHist
   return (
     <FronteggStoreProvider
       {...({ ...props, app } as any)}
-      alwaysVisibleChildren={<CustomComponentRegister app={app} themeOptions={props.themeOptions} />}
+      alwaysVisibleChildren={
+        <>
+          <CustomComponentRegister app={app} themeOptions={props.themeOptions} />
+          {!isExternalHistory && <QueryKeeperWrapper history={history} />}
+        </>
+      }
     />
   );
 };
@@ -109,8 +114,7 @@ export const FronteggProvider: FC<FronteggProviderProps> = (props) => {
 
   if (props.history || history) {
     return (
-      <Connector history={props.history || history} {...props}>
-        {!props.history && <QueryKeeperWrapper history={history} />}
+      <Connector history={props.history || history} isExternalHistory={!!props.history} {...props}>
         {props.children}
       </Connector>
     );


### PR DESCRIPTION
## The Reported Issue
Dev success reported that `includeQueryParam: true` is not working after signup and used to work in older versions.

## The Real Issue
After digging deeper, I discovered that this bug is unrelated to `includeQueryParam`.
The reason we keep the query param after sign-up is because of `queryKeeper` hook in the react SDK.

## The Cause of the bug
The reason for the bug was that we removed the logic of query keeper into the provider. Therefore it won't be called on the login page because the provider hides the children if the user is not authenticated.

## The Fix
1. Remove `QueryKeeperWrapper` to be under `alwaysVisibleChildren` to make it work as before 66dfe7f343d353777326764e6fcb7c3eab44bfce
2. Refactor alwaysVisibleChildren to different component c8723c3851ce9f097b4594609f33ce0284d5de53

## Demo


https://github.com/frontegg/frontegg-react/assets/106734943/80be80a7-bd4d-4f8d-9c85-9ed7ab9cade6

