### PR TITLE
Update Frontegg AdminPortal to 6.192.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "6.191.0",
-    "@frontegg/react-hooks": "6.191.0"
+    "@frontegg/js": "6.192.0",
+    "@frontegg/react-hooks": "6.192.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "6.190.0",
-    "@frontegg/react-hooks": "6.190.0"
+    "@frontegg/js": "6.191.0",
+    "@frontegg/react-hooks": "6.191.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,30 +2514,30 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@6.190.0":
-  version "6.190.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.190.0.tgz#d4da50f081c641a4579bbe1a72601a966e017c99"
-  integrity sha512-em+bRidZIn9/kP/eCBSCSXX4FwwudJCTz5VgNWAyG3l/BpvFAp40ZtgtJZodvkMQawWSSLkpAOSi7qJ+8q5i3A==
+"@frontegg/js@6.191.0":
+  version "6.191.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.191.0.tgz#ba889b425b51dde8259d06c0228047abfb61a14d"
+  integrity sha512-1YdTLRzSAnDIxCGUskcFdRSFWqu6G7KGyeGpgro0cJ71Mt2KkPrlLaTGbBUJeBKuySeUx4qcc+Y0U1qS11iMQw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.190.0"
+    "@frontegg/types" "6.191.0"
 
-"@frontegg/react-hooks@6.190.0":
-  version "6.190.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.190.0.tgz#b0be5d5714a7d33109d411ad723cfa9a5eafe6b6"
-  integrity sha512-OtImBnwJLaq2KQ6znFK01P2Trxg2es8CHJE3CYn1BD0tmL1r3Uzvgw0NafHsvQSDLdhLnpCAWEy5rtcMyLm4Sg==
+"@frontegg/react-hooks@6.191.0":
+  version "6.191.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.191.0.tgz#7298dbc1c0e995941058d0fc9f6960ac064dbaf4"
+  integrity sha512-PZla9qFdZpHJmJNLuAfjSZYf7nRT5+xIilzXjKMrFApiwQzMZGLwzymInPYzGckdP1ggYnQwp7LvEy94TdrgUg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.190.0"
-    "@frontegg/types" "6.190.0"
+    "@frontegg/redux-store" "6.191.0"
+    "@frontegg/types" "6.191.0"
     "@types/react" "*"
     get-value "^3.0.1"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.190.0":
-  version "6.190.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.190.0.tgz#5aad83dd26cb8b407f1d87fe3cd60d6907f1f608"
-  integrity sha512-/Ef6K+X+RrNN3IxGDUrBsZDMASzbPHwPeNN32+8lEpjRIah1PCnth7SkZhfOxqylBxyRxlh4Lp142DOY9D4Nmg==
+"@frontegg/redux-store@6.191.0":
+  version "6.191.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.191.0.tgz#5541ce6287fcbf810405f2ec097e856c7cfd263f"
+  integrity sha512-JDeNcpFwiDKV8aFtYRvtiCVxY+heM3DZxPCPt9lDRXYxJog+fNCTUM7tVSD7qaMDNhSje9yOxnIxidLJCyofXQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
@@ -2555,13 +2555,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@6.190.0":
-  version "6.190.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.190.0.tgz#026e28b0d7b7659997b633ac2550c8ed0237ba09"
-  integrity sha512-x8n5x0b+8GPTeKsLMy/7eyxr6p11GJR3+1f8D1IbZKCeAXPm5K7uguS7JyEwCE/s9GvJjLrGiPks+oGToKwiWw==
+"@frontegg/types@6.191.0":
+  version "6.191.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.191.0.tgz#91ad806570cd2e64d1b13ca13de8796ee8ada8f5"
+  integrity sha512-JgVqWHpGYk449ojxhzPSCHCTW8zoqdTHDA47lM+QAn81zy9kQ1r0uKkcWR/gLn6vtbHs5Z5kSq5OcaBFEEu1hA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.190.0"
+    "@frontegg/redux-store" "6.191.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,30 +2514,30 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@6.191.0":
-  version "6.191.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.191.0.tgz#ba889b425b51dde8259d06c0228047abfb61a14d"
-  integrity sha512-1YdTLRzSAnDIxCGUskcFdRSFWqu6G7KGyeGpgro0cJ71Mt2KkPrlLaTGbBUJeBKuySeUx4qcc+Y0U1qS11iMQw==
+"@frontegg/js@6.192.0":
+  version "6.192.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-6.192.0.tgz#0ed78d44fbbebbff54d9866f6b71cd91ddeba26f"
+  integrity sha512-dzJKgE3JXxIVtPX4RsQYvxYRSbjG7NA4rkSsWqAThD69zB8d070LQMAy8yBqEsKFTgWZz+wcxbrTD30N+7XntA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "6.191.0"
+    "@frontegg/types" "6.192.0"
 
-"@frontegg/react-hooks@6.191.0":
-  version "6.191.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.191.0.tgz#7298dbc1c0e995941058d0fc9f6960ac064dbaf4"
-  integrity sha512-PZla9qFdZpHJmJNLuAfjSZYf7nRT5+xIilzXjKMrFApiwQzMZGLwzymInPYzGckdP1ggYnQwp7LvEy94TdrgUg==
+"@frontegg/react-hooks@6.192.0":
+  version "6.192.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-6.192.0.tgz#bf7d997e46064cd48176c68af8b7e5c4c6585951"
+  integrity sha512-/zMTExv2f8NFxHvp4gUf44kJN8FatcLRyjK9+JZZND9U81ZLqhy958p5JBNWPKxIAUdBOjYQHB392zbqdGEBGg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.191.0"
-    "@frontegg/types" "6.191.0"
+    "@frontegg/redux-store" "6.192.0"
+    "@frontegg/types" "6.192.0"
     "@types/react" "*"
     get-value "^3.0.1"
     react-redux "^7.x"
 
-"@frontegg/redux-store@6.191.0":
-  version "6.191.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.191.0.tgz#5541ce6287fcbf810405f2ec097e856c7cfd263f"
-  integrity sha512-JDeNcpFwiDKV8aFtYRvtiCVxY+heM3DZxPCPt9lDRXYxJog+fNCTUM7tVSD7qaMDNhSje9yOxnIxidLJCyofXQ==
+"@frontegg/redux-store@6.192.0":
+  version "6.192.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-6.192.0.tgz#306feac23232ba9e7cc068ee52501050724df5a5"
+  integrity sha512-8hErbQtAiFZDuqPZJgqig7Up603D4TM+nMs/L6JolasZt/+z2U/Db9zyJCrCyvEGer5xQO+TCBYr4AQHsO2GWw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
@@ -2555,13 +2555,13 @@
     "@babel/runtime" "^7.17.2"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@6.191.0":
-  version "6.191.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.191.0.tgz#91ad806570cd2e64d1b13ca13de8796ee8ada8f5"
-  integrity sha512-JgVqWHpGYk449ojxhzPSCHCTW8zoqdTHDA47lM+QAn81zy9kQ1r0uKkcWR/gLn6vtbHs5Z5kSq5OcaBFEEu1hA==
+"@frontegg/types@6.192.0":
+  version "6.192.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-6.192.0.tgz#a791b4b51193082c7d1df5fd7307932a47d7cbe7"
+  integrity sha512-5gFNN5Wcv66h9UxY78eUi37uBs5PANhLX37X7ZTxge4tI32uSNy38yUxqgcbA07/zM6xtFjOKSap1iui2Htf5A==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "6.191.0"
+    "@frontegg/redux-store" "6.192.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-15124 - Store redirectUri before social-login as oauth2 state and restore it after successfully redirect
- FR-16117 - avoid showing apps without name in users table

- FR-16165 - Added switch tenant functionality for VanillaJS SDK