### PR TITLE
Update Frontegg AdminPortal to 7.66.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "7.65.0",
-    "@frontegg/react-hooks": "7.65.0"
+    "@frontegg/js": "7.66.0",
+    "@frontegg/react-hooks": "7.66.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,57 +2514,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.65.0":
-  version "7.65.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.65.0.tgz#b7796bedda70fb749e2cddd5cb4d94e93f676bff"
-  integrity sha512-gkcZUizZ/wKBLri32E+5VT+sRqcXW4HxAoiNdmaHnVQijtSw77CNORSY7GKSbjacEmURU8nnQ/TwSPdlyLG1iQ==
+"@frontegg/js@7.66.0":
+  version "7.66.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.66.0.tgz#31a384e93fc8d31a4220c9371d4f6cc05fe74e48"
+  integrity sha512-dFlBCIEStuw5THjVjgsqcR5wzWsQq3rB4lJpPIjjZI1Q8fNsTj2uIvA081UNzaLeg08I5vIPm6qAf9+3ct+uOQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.65.0"
+    "@frontegg/types" "7.66.0"
 
-"@frontegg/react-hooks@7.65.0":
-  version "7.65.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.65.0.tgz#15bb5d5a8dfbada08c1e88e3db219c08ffca0b39"
-  integrity sha512-1W4GRhhOWS1xLY1Fq7xuW/FbYtfhUYLh1OJ+Q/XdEes77cWPfPDb78yJ7rIGhAYefZ6QiyjKsJhcAzx6LPO/1g==
+"@frontegg/react-hooks@7.66.0":
+  version "7.66.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.66.0.tgz#bc0eebf3308cc9273bf844a6f37c304f5cf6e6f4"
+  integrity sha512-UA4L7WL9L3qcBIKzRElPjCRzEyKz990/xKT/fMGfTyGVn/A/JbmNLD+O+AG13m9/aijcJgFG9cK+8sMgcUkLew==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.65.0"
-    "@frontegg/types" "7.65.0"
+    "@frontegg/redux-store" "7.66.0"
+    "@frontegg/types" "7.66.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.65.0":
-  version "7.65.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.65.0.tgz#38a55e5eb82297fb8c7bc7b140594de66fcf087e"
-  integrity sha512-5LbWhEiW+QdUPjZEnWoz5uNo1m56npawo65i9NuJzfi5n/03MsBReqagbTb8ujV+1oYw3d4zy5Jh+rrUxknbyQ==
+"@frontegg/redux-store@7.66.0":
+  version "7.66.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.66.0.tgz#9f6a561bd604db85e722e72bed62e4398033d0d1"
+  integrity sha512-FBpvrBsyrmbqn4CNqb7a7aZHMG4LRoni9N/fAN+z3Arc2EPY3zhbNQy8uUfVWWGB1hv9MWL2Rp2zxd/JzOOcYw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.65.0"
+    "@frontegg/rest-api" "7.66.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.65.0":
-  version "7.65.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.65.0.tgz#8003ea6666fe322767c43cc61999bd4890f2a295"
-  integrity sha512-gQ7ajC/G/SL+qO+p3mdcCqf82glUethuTf4U5m34ics0RG0ZlOYAsVVJrKa7vXxxBC5Ee3XlT7wcqWj2VdVtQw==
+"@frontegg/rest-api@7.66.0":
+  version "7.66.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.66.0.tgz#017a021508382a85f2b9dcb28ebd641226561ae4"
+  integrity sha512-ThUNjzy6bt55c0bfKxDQ/ywbXxYHw5cxA5IOOgtR5Q6gqL3cpuL25zf6KdJ0l8XIlVoRJMkv7ySv/6BYcs/O/A==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.65.0":
-  version "7.65.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.65.0.tgz#d06ab8a4d4732e5a910f78e6bf3ff2141ef3a8e8"
-  integrity sha512-sLZgIEDWvzaWPxKw8w9fFCAXKqcVuRVtyJmNF2wiKjnydTZdYZNiA1O5kJWwgbl465p96MA0H0wo579Kl4o3gg==
+"@frontegg/types@7.66.0":
+  version "7.66.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.66.0.tgz#0da1c1a8cdf88c7415f646fd8abd2f02783cca67"
+  integrity sha512-x10ZuoIRHfaX8cOSq3f1cJrJ/9NOs1fW8wjbmNwMFmS8ZiQ00k7i+U3nq2DLS/cqAgf6LOc4X0Gv2hHLn1W4bA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.65.0"
+    "@frontegg/redux-store" "7.66.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-20267 - Added support for direction by metadata
- FR-20250 - Fixed min optional tests on password strength
- FR-19976 - Fixed pre step shouldn&#39;t appear when shouldSetPassword is not false
