### PR TITLE
Update Frontegg AdminPortal to 7.67.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "7.66.0",
-    "@frontegg/react-hooks": "7.66.0"
+    "@frontegg/js": "7.67.0",
+    "@frontegg/react-hooks": "7.67.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,57 +2514,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.66.0":
-  version "7.66.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.66.0.tgz#31a384e93fc8d31a4220c9371d4f6cc05fe74e48"
-  integrity sha512-dFlBCIEStuw5THjVjgsqcR5wzWsQq3rB4lJpPIjjZI1Q8fNsTj2uIvA081UNzaLeg08I5vIPm6qAf9+3ct+uOQ==
+"@frontegg/js@7.67.0":
+  version "7.67.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.67.0.tgz#85e173877d515b487f7c2ce7c230da4b93e4c57f"
+  integrity sha512-OEUvbqo26oZEpkBy4FyaiCdOCGT5Qz71kFAWDkZmc55aiT8wZB/GEjmnzsTsutf4qRj8hTKysIFCa8z7/e2X7g==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.66.0"
+    "@frontegg/types" "7.67.0"
 
-"@frontegg/react-hooks@7.66.0":
-  version "7.66.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.66.0.tgz#bc0eebf3308cc9273bf844a6f37c304f5cf6e6f4"
-  integrity sha512-UA4L7WL9L3qcBIKzRElPjCRzEyKz990/xKT/fMGfTyGVn/A/JbmNLD+O+AG13m9/aijcJgFG9cK+8sMgcUkLew==
+"@frontegg/react-hooks@7.67.0":
+  version "7.67.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.67.0.tgz#58c8ed2571860671bdba52c4c8faf99086438cb9"
+  integrity sha512-GjhH9O8rrJYR1qApm4KHCgvTsUPFJZDj8TlHaPpStnkNXvHPDKxxQmR2eA0JzIUN0Tm5eJC/qd4fk9SNXxFE1g==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.66.0"
-    "@frontegg/types" "7.66.0"
+    "@frontegg/redux-store" "7.67.0"
+    "@frontegg/types" "7.67.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.66.0":
-  version "7.66.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.66.0.tgz#9f6a561bd604db85e722e72bed62e4398033d0d1"
-  integrity sha512-FBpvrBsyrmbqn4CNqb7a7aZHMG4LRoni9N/fAN+z3Arc2EPY3zhbNQy8uUfVWWGB1hv9MWL2Rp2zxd/JzOOcYw==
+"@frontegg/redux-store@7.67.0":
+  version "7.67.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.67.0.tgz#986ccdaa136fdb54a424b880f3fdf35c008152ba"
+  integrity sha512-oaNBnFmfeBTdtUN7/nAOcoNrZNW/XzJPTclDsicjLY4zec8PpnJShdY1+rjw2GPTQFYIZMShRMfQWaZiuV7O0g==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.66.0"
+    "@frontegg/rest-api" "7.67.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.66.0":
-  version "7.66.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.66.0.tgz#017a021508382a85f2b9dcb28ebd641226561ae4"
-  integrity sha512-ThUNjzy6bt55c0bfKxDQ/ywbXxYHw5cxA5IOOgtR5Q6gqL3cpuL25zf6KdJ0l8XIlVoRJMkv7ySv/6BYcs/O/A==
+"@frontegg/rest-api@7.67.0":
+  version "7.67.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.67.0.tgz#1d1470564c87ee7eb039d9a6e9df138457d7eefe"
+  integrity sha512-8SkrMBRfH9rY01eCK8ohuJ4cojWWzuEodijCJhoyj2px44zHnyDJhf++3HmhwuCzTLsgUUz/exA8eXA63BbHlQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.66.0":
-  version "7.66.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.66.0.tgz#0da1c1a8cdf88c7415f646fd8abd2f02783cca67"
-  integrity sha512-x10ZuoIRHfaX8cOSq3f1cJrJ/9NOs1fW8wjbmNwMFmS8ZiQ00k7i+U3nq2DLS/cqAgf6LOc4X0Gv2hHLn1W4bA==
+"@frontegg/types@7.67.0":
+  version "7.67.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.67.0.tgz#ba476b20dbec4b95b20085fa74b6f65e61266f58"
+  integrity sha512-3/cRr52UHkQvz6x8g98/GskZtLCMip3dy7lCbd36ntNky67X5B1LZ7lcaExQZkJFbmTf4N+F9pU+6xwwMeoM+w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.66.0"
+    "@frontegg/redux-store" "7.67.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-18986 - Added tooltip functionality for individual chips in GroupsChipsList component
- FR-20385 - Fixed user impersonation with identifiers
- FR-20254 - Added localizations for activate with social logins
- FR-20280 - Added support for signup with phone number
