### PR TITLE
Update Frontegg AdminPortal to 7.76.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "7.75.0",
-    "@frontegg/react-hooks": "7.75.0"
+    "@frontegg/js": "7.76.0",
+    "@frontegg/react-hooks": "7.76.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,57 +2514,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.75.0":
-  version "7.75.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.75.0.tgz#cf21155057d6b38a0a1f8d18200c9aa09c2dcc2f"
-  integrity sha512-w2wsTpS3g2gA5j70Av2tsZUaSv3+ofxvDQArxE9Oq4Xm3IFUO9QkZVpY1DX1/7p1XsXexEr/3M8m0X8MvFoM2w==
+"@frontegg/js@7.76.0":
+  version "7.76.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.76.0.tgz#8a79b42b4be5958efe013fc7154b7d2e1bb3bc15"
+  integrity sha512-jDCPUs0scC6O3+Ke9S/fFxujsVrJZ6QIWhTUVMy2mCsSMAmoiGzqD9ZrX7HBmTgzbXL9xOA5F+lnsj7AKaNAqg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.75.0"
+    "@frontegg/types" "7.76.0"
 
-"@frontegg/react-hooks@7.75.0":
-  version "7.75.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.75.0.tgz#cf9786c8771325f92804c9c545dd230dc1f91cc8"
-  integrity sha512-nl/AVmwSuV+EcH5M3fNmePepMsxIxBlHy3JSr0cPdqwhJin8synbPTE+w25tBVKcb9IbiqaG6ITEmqPMwm6oIA==
+"@frontegg/react-hooks@7.76.0":
+  version "7.76.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.76.0.tgz#41344b00b5f820b58f930f0ffd7d587be9fca61b"
+  integrity sha512-kuLm12ecckGXKzeY7bDRZBdPDgxAERN+t/4z2q5sLw2WHzcnF7h1Zm9PIWEjkcAUp+pRmTKTUOW/i/++NCcu1A==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.75.0"
-    "@frontegg/types" "7.75.0"
+    "@frontegg/redux-store" "7.76.0"
+    "@frontegg/types" "7.76.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.75.0":
-  version "7.75.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.75.0.tgz#cf76efb938862c83555dad3c5a9514dafacebbbc"
-  integrity sha512-0ohJogASOkZiB3wrrqGyEAaFaNT4p42Tu/6RShzLg6hNLs6VnIGwY6nX3/aORS1jxQ7TY5cbIhhFngCJH9ojBA==
+"@frontegg/redux-store@7.76.0":
+  version "7.76.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.76.0.tgz#7e532c04cb89b5a2565ae4e5e568f98d29b09e22"
+  integrity sha512-qJge3cOFJGijK15zutnAtHjYtKRvZtjWAtis7WeSoNlpkin0n4hg/2Nlfg0DGdxarESK9x5lwZueTzWlWWpN2A==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.75.0"
+    "@frontegg/rest-api" "7.76.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.75.0":
-  version "7.75.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.75.0.tgz#4cdd078ed93b6d56767db64acf2515d7a2e499ce"
-  integrity sha512-KPC+TNh4G168FJErsDY4qRS7CgYyvZk9X20PA/wKfmH+dV2wn08kDF8z5dCSkE+lOy88U/5IAgC/kgYDbIFxew==
+"@frontegg/rest-api@7.76.0":
+  version "7.76.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.76.0.tgz#7cb9695a26b8ba5a514eda4339b55fe13c1df4b6"
+  integrity sha512-RdZvKhAfzAO8u1wmdS3+30553C62QhW3p5ioXZugfv1wyGXURlqocWsmhIxJsQcK5BiROxdP0ZyGvuLMDPaOSw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.75.0":
-  version "7.75.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.75.0.tgz#bb2f07ce619e715800e7fc0e5d46f2547409897f"
-  integrity sha512-oJqwEhBw/hRzrz2OGSStcWTdFOEmkawFNyNjOlacJRvpVbApb/TMWm/HxWOj6FCCzQu57kiXf2kdpiDXZ7yZew==
+"@frontegg/types@7.76.0":
+  version "7.76.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.76.0.tgz#1845056b2c0094cd2dfe02645783f5255b626b33"
+  integrity sha512-8Jwm8gptW9a1YJMOAVo1X8xUgOkeYWvuOJ7JYK2b/OpBurs6AySwKsBLuN7kfwvWShuOxlVq6ECnNOK8ICfRgw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.75.0"
+    "@frontegg/redux-store" "7.76.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-20862 - Fixed useLoginHint and add tests to simulate hosted prelogin flow
- FR-21121 - Added reset password with email&#x2F;sms actions and a Forgot password sms otc page 
- FR-21097 - Added suspense to renderCMCComponent
- FR-21120 - Added BaseOTC component and use it in login otc flows
- FR-21112 - Added password recovery selector and a determinePasswordRecoveryStrategy function
- FR-21118 - Fixed default language handle
- FR-20838 - Added search functionality to roles popper
- FR-20178 - Added generic IdentifierField and used it in login and forgot password flows
- FR-20945 - Added username in profile
- FR-20868 - Added usernames
