### PR TITLE
FR-23484 - Added an option to render SSO guides outside of admin box

### DIFF
--- a/packages/demo-saas/src/App.tsx
+++ b/packages/demo-saas/src/App.tsx
@@ -8,6 +8,7 @@ import { authOptions } from './customizationOptions/authOptions';
 import HomePage from './HomePage';
 import CMCPage from './cmc/CMCPage';
 import CMCSsoPage from './cmc/CMCSsoPage';
+import CMCScimPage from './cmc/CMCScimPage';
 import ModalsStepUpPage from './stepUp/ModalsStepUpPage';
 import HOCStepUpPage from './stepUp/HOCStepUpPage';
 import SimpleStepUpButtonPage from './stepUp/SimpleStepUpButtonPage';
@@ -56,6 +57,7 @@ export const App: FC = () => {
           <Route path={ROUTE_PATHS.STEP_UP_TRANSFER} exact render={TransferStepUpPage} />
           <Route path={ROUTE_PATHS.CMC} exact render={CMCPage} />
           <Route path={ROUTE_PATHS.CMC_SSO} exact render={CMCSsoPage} />
+          <Route path={ROUTE_PATHS.CMC_SCIM} exact render={CMCScimPage} />
           {/* For tests that use someurl as the authenticated-url */}
           <Route path={'/someurl'} exact render={NotAFronteggPage} />
           <Route

--- a/packages/demo-saas/src/App.tsx
+++ b/packages/demo-saas/src/App.tsx
@@ -27,10 +27,8 @@ const fronteggOptions: FronteggAppOptions =
   window.CYPRESS_CONFIG ||
   ({
     contextOptions: {
-      // baseUrl: process.env.PUBLIC_URL || process.env.REACT_APP_BASE_URL || DEFAULT_BASE_URL,
-      // clientId: process.env.REACT_APP_CLIENT_ID,
-      baseUrl: 'https://lo79zr4y62rl7ajdx1cw1l.stg.frontegg.com',
-      clientId: '4d6c894a-2b28-496f-aec8-143f6c31766f',
+      baseUrl: process.env.PUBLIC_URL || process.env.REACT_APP_BASE_URL || DEFAULT_BASE_URL,
+      clientId: process.env.REACT_APP_CLIENT_ID,
     },
     ...authOptions,
     enableOpenAppRoute: true,

--- a/packages/demo-saas/src/App.tsx
+++ b/packages/demo-saas/src/App.tsx
@@ -7,6 +7,7 @@ import { FronteggAppOptions } from '@frontegg/types';
 import { authOptions } from './customizationOptions/authOptions';
 import HomePage from './HomePage';
 import CMCPage from './cmc/CMCPage';
+import CMCSsoPage from './cmc/CMCSsoPage';
 import ModalsStepUpPage from './stepUp/ModalsStepUpPage';
 import HOCStepUpPage from './stepUp/HOCStepUpPage';
 import SimpleStepUpButtonPage from './stepUp/SimpleStepUpButtonPage';
@@ -26,8 +27,10 @@ const fronteggOptions: FronteggAppOptions =
   window.CYPRESS_CONFIG ||
   ({
     contextOptions: {
-      baseUrl: process.env.PUBLIC_URL || process.env.REACT_APP_BASE_URL || DEFAULT_BASE_URL,
-      clientId: process.env.REACT_APP_CLIENT_ID,
+      // baseUrl: process.env.PUBLIC_URL || process.env.REACT_APP_BASE_URL || DEFAULT_BASE_URL,
+      // clientId: process.env.REACT_APP_CLIENT_ID,
+      baseUrl: 'https://lo79zr4y62rl7ajdx1cw1l.stg.frontegg.com',
+      clientId: '4d6c894a-2b28-496f-aec8-143f6c31766f',
     },
     ...authOptions,
     enableOpenAppRoute: true,
@@ -54,6 +57,7 @@ export const App: FC = () => {
           <Route path={ROUTE_PATHS.STEP_UP_HOC} exact render={HOCStepUpPage} />
           <Route path={ROUTE_PATHS.STEP_UP_TRANSFER} exact render={TransferStepUpPage} />
           <Route path={ROUTE_PATHS.CMC} exact render={CMCPage} />
+          <Route path={ROUTE_PATHS.CMC_SSO} exact render={CMCSsoPage} />
           {/* For tests that use someurl as the authenticated-url */}
           <Route path={'/someurl'} exact render={NotAFronteggPage} />
           <Route

--- a/packages/demo-saas/src/App.tsx
+++ b/packages/demo-saas/src/App.tsx
@@ -28,8 +28,10 @@ const fronteggOptions: FronteggAppOptions =
   window.CYPRESS_CONFIG ||
   ({
     contextOptions: {
-      baseUrl: process.env.PUBLIC_URL || process.env.REACT_APP_BASE_URL || DEFAULT_BASE_URL,
-      clientId: process.env.REACT_APP_CLIENT_ID,
+      // baseUrl: process.env.PUBLIC_URL || process.env.REACT_APP_BASE_URL || DEFAULT_BASE_URL,
+      // clientId: process.env.REACT_APP_CLIENT_ID,
+      baseUrl: 'https://uin4mfouvdqh31viy4svah.stg.frontegg.com',
+      clientId: '3137663b-db5e-45dd-aaec-9814012d286d',
     },
     ...authOptions,
     enableOpenAppRoute: true,

--- a/packages/demo-saas/src/BaseHomePage/components/Links.tsx
+++ b/packages/demo-saas/src/BaseHomePage/components/Links.tsx
@@ -27,6 +27,7 @@ export const ROUTE_PATHS = {
   TEST: '/test',
   CMC: '/cmc',
   CMC_SSO: '/cmc-sso',
+  CMC_SCIM: '/cmc-scim',
 };
 
 const links = [
@@ -42,6 +43,7 @@ const links = [
   { route: ROUTE_PATHS.TEST, label: 'Old test' },
   { route: ROUTE_PATHS.CMC, label: 'CMC' },
   { route: ROUTE_PATHS.CMC_SSO, label: 'CMC SSO' },
+  { route: ROUTE_PATHS.CMC_SCIM, label: 'CMC SCIM' },
 ];
 
 export const Links = () => (

--- a/packages/demo-saas/src/BaseHomePage/components/Links.tsx
+++ b/packages/demo-saas/src/BaseHomePage/components/Links.tsx
@@ -26,6 +26,7 @@ export const ROUTE_PATHS = {
   UNKNOWN_ROUTE: '/unknown-route',
   TEST: '/test',
   CMC: '/cmc',
+  CMC_SSO: '/cmc-sso',
 };
 
 const links = [
@@ -40,6 +41,7 @@ const links = [
   { route: ROUTE_PATHS.UNKNOWN_ROUTE, label: 'Fallback route' },
   { route: ROUTE_PATHS.TEST, label: 'Old test' },
   { route: ROUTE_PATHS.CMC, label: 'CMC' },
+  { route: ROUTE_PATHS.CMC_SSO, label: 'CMC SSO' },
 ];
 
 export const Links = () => (

--- a/packages/demo-saas/src/cmc/CMCScimPage.tsx
+++ b/packages/demo-saas/src/cmc/CMCScimPage.tsx
@@ -1,24 +1,20 @@
-import React, { useCallback, useEffect } from 'react';
-import { SsoGuideDialog, useAuthActions } from '@frontegg/react';
+import React, { useCallback } from 'react';
+import { ScimGuideDialog } from '@frontegg/react';
 import { wrapWithBaseHomePage } from '../BaseHomePage/BaseHomePage';
 
 const Page = () => {
   const handleGuideClose = useCallback((result: any) => {
-    console.log('Guide closed with result:', result);
+    console.log('SCIM Guide closed with result:', result);
   }, []);
-  const { loadSSOConfigurationsV2 } = useAuthActions();
-  useEffect(() => {
-    loadSSOConfigurationsV2();
-  }, [loadSSOConfigurationsV2]);
 
   return (
     <div style={{ width: '500px' }}>
-      <h1>SSO Guide Dialog</h1>
-      <SsoGuideDialog
+      <h1>SCIM Guide Dialog</h1>
+      <ScimGuideDialog
         props={{
-          id: 'sso-guide-dialog',
+          id: 'scim-guide-dialog',
           onClose: handleGuideClose,
-          showSelector: true,
+          getConnectionName: (provider: any) => `${provider.name} - ${provider.id}`,
         }}
         themeOptions={{}}
         containerStyle={{

--- a/packages/demo-saas/src/cmc/CMCSsoPage.tsx
+++ b/packages/demo-saas/src/cmc/CMCSsoPage.tsx
@@ -1,0 +1,35 @@
+import React, { useCallback, useEffect } from 'react';
+import { SsoGuideDialog, useAuthActions } from '@frontegg/react';
+import { wrapWithBaseHomePage } from '../BaseHomePage/BaseHomePage';
+
+const Page = () => {
+  const handleGuideClose = useCallback((result: any) => {
+    console.log('Guide closed with result:', result);
+  }, []);
+  const { loadSSOConfigurationsV2 } = useAuthActions();
+  useEffect(() => {
+    loadSSOConfigurationsV2();
+  }, [loadSSOConfigurationsV2]);
+
+  return (
+    <div style={{ width: '500px' }}>
+      <h1>SSO Guide Dialog</h1>
+      <SsoGuideDialog
+        props={{
+          onClose: handleGuideClose,
+          showSelector: true,
+        }}
+        themeOptions={{}}
+        containerStyle={{
+          display: 'block',
+          flexDirection: undefined,
+        }}
+      />
+    </div>
+  );
+};
+
+export default wrapWithBaseHomePage(Page, {
+  width: '95vw',
+  minWidth: '1200px',
+});

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "7.101.0-alpha.1",
-    "@frontegg/react-hooks": "7.101.0-alpha.1"
+    "@frontegg/js": "7.101.0-alpha.2",
+    "@frontegg/react-hooks": "7.101.0-alpha.2"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "7.99.0",
-    "@frontegg/react-hooks": "7.99.0"
+    "@frontegg/js": "7.100.0-alpha.4",
+    "@frontegg/react-hooks": "7.100.0-alpha.4"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "7.100.0-alpha.4",
-    "@frontegg/react-hooks": "7.100.0-alpha.4"
+    "@frontegg/js": "7.101.0-alpha.1",
+    "@frontegg/react-hooks": "7.101.0-alpha.1"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "7.101.0",
-    "@frontegg/react-hooks": "7.101.0"
+    "@frontegg/js": "7.102.0-alpha.0",
+    "@frontegg/react-hooks": "7.102.0-alpha.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/packages/react/src/cmc/CMC_IMPLEMENTATION_GUIDE.md
+++ b/packages/react/src/cmc/CMC_IMPLEMENTATION_GUIDE.md
@@ -1,0 +1,199 @@
+# CMC (Custom Modal Component) Implementation Guide
+
+This guide documents how to add a new CMC component to the demo-saas app.
+
+## Overview
+
+CMC components are React wrappers around `@frontegg/js` render functions. They allow embedding Frontegg admin portal components directly into your application.
+
+## Architecture
+
+```
+@frontegg/js (FronteggApp)
+    ↓ renderXxx methods
+packages/react/src/cmc/cmc-base.tsx (CMCComponent)
+    ↓ wraps render methods
+packages/react/src/cmc/cmc-components.tsx (Exported components)
+    ↓ used in
+packages/demo-saas/src/cmc/CMCXxxPage.tsx (Demo pages)
+```
+
+## Files to Modify/Create
+
+### 1. Check if the render method exists in `@frontegg/js`
+
+The component must have a corresponding render method in `FronteggApp`. Current methods:
+- `renderChangePasswordForm`
+- `renderInviteUserDialog`
+- `renderProfilePage`
+- `renderUsersTable`
+- `renderSsoGuideDialog`
+
+### 2. Update `cmc-base.tsx` (if adding a new render method)
+
+Add the new render method to `RenderableFronteggComponent` type:
+
+```typescript
+export type RenderableFronteggComponent = keyof Pick<
+  FronteggApp,
+  | 'renderChangePasswordForm'
+  | 'renderInviteUserDialog'
+  | 'renderProfilePage'
+  | 'renderUsersTable'
+  | 'renderSsoGuideDialog'
+  | 'renderNewComponent'  // Add new method here
+>;
+```
+
+### 3. Add component wrapper in `cmc-components.tsx`
+
+```typescript
+import { NewComponentProps } from '@frontegg/types';
+
+export const NewComponent: FC<FronteggCMCComponentProps<NewComponentProps>> = (props) => {
+  return <CMCComponent renderComponent='renderNewComponent' {...props} />;
+};
+```
+
+### 4. Export from `@frontegg/react` index
+
+Make sure the new component is exported from the package's index file.
+
+### 5. Create demo page in `demo-saas`
+
+Create a new file: `packages/demo-saas/src/cmc/CMCNewComponentPage.tsx`
+
+```typescript
+import React, { useCallback, useEffect } from 'react';
+import { NewComponent, useAuthActions } from '@frontegg/react';
+import { wrapWithBaseHomePage } from '../BaseHomePage/BaseHomePage';
+
+const Page = () => {
+  // Optional: Load any required data
+  const { loadRequiredData } = useAuthActions();
+  useEffect(() => {
+    loadRequiredData();
+  }, [loadRequiredData]);
+
+  // Optional: Handle callbacks
+  const handleClose = useCallback((result: any) => {
+    console.log('Component closed with result:', result);
+  }, []);
+
+  return (
+    <div style={{ width: '500px' }}>
+      <h1>New Component</h1>
+      <NewComponent
+        props={{
+          onClose: handleClose,
+          // ... other props from NewComponentProps
+        }}
+        themeOptions={{}}
+        containerStyle={{
+          // Styles passed to @frontegg/js render method
+        }}
+        hostStyle={{
+          // Styles for the wrapper div
+        }}
+      />
+    </div>
+  );
+};
+
+export default wrapWithBaseHomePage(Page, {
+  width: '80vw',
+  minWidth: '300px',
+});
+```
+
+### 6. Add route in `Links.tsx`
+
+```typescript
+export const ROUTE_PATHS = {
+  // ... existing routes
+  CMC_NEW_COMPONENT: '/cmc-new-component',
+};
+
+const links = [
+  // ... existing links
+  { route: ROUTE_PATHS.CMC_NEW_COMPONENT, label: 'CMC New Component' },
+];
+```
+
+### 7. Add route in `App.tsx`
+
+```typescript
+import CMCNewComponentPage from './cmc/CMCNewComponentPage';
+
+// In the Switch component:
+<Route path={ROUTE_PATHS.CMC_NEW_COMPONENT} exact render={CMCNewComponentPage} />
+```
+
+## Props Reference
+
+### `FronteggCMCComponentProps<T>`
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `props` | `T` | Component-specific props (e.g., `onClose`, `showSelector`) |
+| `themeOptions` | `object` | MUI theme overrides for admin portal components |
+| `localizations` | `object` | Localization strings |
+| `hostStyle` | `CSSProperties` | Styles for the wrapper `<div>` element |
+| `containerStyle` | `CSSProperties` | Styles passed to `@frontegg/js` render method |
+
+## Styling Notes
+
+1. **`hostStyle`** - Applied to the React wrapper div. Use for positioning and sizing the container.
+
+2. **`containerStyle`** - Passed to `@frontegg/js` and applied to the internal container. Use for styling the rendered content.
+
+3. **`themeOptions`** - MUI theme overrides. Structure:
+   ```typescript
+   themeOptions={{
+     adminPortal: {
+       components: {
+         MuiComponent: {
+           styleOverrides: {
+             root: { /* styles */ },
+           },
+         },
+       },
+     },
+   }}
+   ```
+
+4. **Width considerations** - The parent container width affects internal layout. Some components (like SsoGuideDialog) have responsive layouts that change based on available width.
+
+## Common Patterns
+
+### Loading data before render
+
+Some CMC components require data to be loaded first:
+
+```typescript
+const { loadSSOConfigurationsV2 } = useAuthActions();
+useEffect(() => {
+  loadSSOConfigurationsV2();
+}, [loadSSOConfigurationsV2]);
+```
+
+### Handling dialog close
+
+```typescript
+const handleClose = useCallback((result: any) => {
+  console.log('Closed with result:', result);
+  // Navigate away, show success message, etc.
+}, []);
+
+<Component props={{ onClose: handleClose }} />
+```
+
+## Existing CMC Components
+
+| Component | Render Method | Props Type | Description |
+|-----------|---------------|------------|-------------|
+| `UsersTable` | `renderUsersTable` | `UsersTableProps` | User management table |
+| `InviteUserDialog` | `renderInviteUserDialog` | `InviteUserDialogProps` | User invitation modal |
+| `ChangePasswordForm` | `renderChangePasswordForm` | `ChangePasswordFormProps` | Password change form |
+| `ProfilePage` | `renderProfilePage` | `ProfilePageProps` | User profile page |
+| `SsoGuideDialog` | `renderSsoGuideDialog` | `SsoGuideDialogProps` | SSO configuration guide |

--- a/packages/react/src/cmc/cmc-base.tsx
+++ b/packages/react/src/cmc/cmc-base.tsx
@@ -5,17 +5,17 @@ import { FC } from 'react';
 
 export type RenderableFronteggComponent = keyof Pick<
   FronteggApp,
-  'renderChangePasswordForm' | 'renderInviteUserDialog' | 'renderProfilePage' | 'renderUsersTable'
+  'renderChangePasswordForm' | 'renderInviteUserDialog' | 'renderProfilePage' | 'renderUsersTable' | 'renderSsoGuideDialog'
 >;
 export type FronteggCMCComponentProps<K extends CMCComponentProps> = Pick<
   K,
-  'themeOptions' | 'props' | 'localizations' | 'hostStyle'
+  'themeOptions' | 'props' | 'localizations' | 'hostStyle' | 'containerStyle' 
 >;
 
 export const CMCComponent: FC<
   FronteggCMCComponentProps<CMCComponentProps> & { renderComponent: RenderableFronteggComponent }
 > = memo(
-  ({ themeOptions, props, localizations, hostStyle, renderComponent }) => {
+  ({ themeOptions, props, localizations, hostStyle, renderComponent, containerStyle }) => {
     const ref = React.useRef<HTMLDivElement>(null);
     React.useLayoutEffect(() => {
       const app = AppHolder.getInstance('default');
@@ -34,6 +34,7 @@ export const CMCComponent: FC<
       app[renderComponent](ref.current, props, {
         themeOptions,
         localizations,
+        containerStyle
       }).then((root) => (rootRendered = root));
     }, []);
 

--- a/packages/react/src/cmc/cmc-base.tsx
+++ b/packages/react/src/cmc/cmc-base.tsx
@@ -10,6 +10,7 @@ export type RenderableFronteggComponent = keyof Pick<
   | 'renderProfilePage'
   | 'renderUsersTable'
   | 'renderSsoGuideDialog'
+  | 'renderScimGuideDialog'
 >;
 export type FronteggCMCComponentProps<K extends CMCComponentProps> = Pick<
   K,

--- a/packages/react/src/cmc/cmc-base.tsx
+++ b/packages/react/src/cmc/cmc-base.tsx
@@ -5,11 +5,15 @@ import { FC } from 'react';
 
 export type RenderableFronteggComponent = keyof Pick<
   FronteggApp,
-  'renderChangePasswordForm' | 'renderInviteUserDialog' | 'renderProfilePage' | 'renderUsersTable' | 'renderSsoGuideDialog'
+  | 'renderChangePasswordForm'
+  | 'renderInviteUserDialog'
+  | 'renderProfilePage'
+  | 'renderUsersTable'
+  | 'renderSsoGuideDialog'
 >;
 export type FronteggCMCComponentProps<K extends CMCComponentProps> = Pick<
   K,
-  'themeOptions' | 'props' | 'localizations' | 'hostStyle' | 'containerStyle' 
+  'themeOptions' | 'props' | 'localizations' | 'hostStyle' | 'containerStyle'
 >;
 
 export const CMCComponent: FC<
@@ -34,7 +38,7 @@ export const CMCComponent: FC<
       app[renderComponent](ref.current, props, {
         themeOptions,
         localizations,
-        containerStyle
+        containerStyle,
       }).then((root) => (rootRendered = root));
     }, []);
 

--- a/packages/react/src/cmc/cmc-components.tsx
+++ b/packages/react/src/cmc/cmc-components.tsx
@@ -2,6 +2,7 @@ import {
   ChangePasswordFormProps,
   InviteUserDialogProps,
   ProfilePageProps,
+  ScimGuideDialogProps,
   SsoGuideDialogProps,
   UsersTableProps,
 } from '@frontegg/types';
@@ -26,4 +27,8 @@ export const ProfilePage: FC<FronteggCMCComponentProps<ProfilePageProps>> = (pro
 
 export const SsoGuideDialog: FC<FronteggCMCComponentProps<SsoGuideDialogProps>> = (props) => {
   return <CMCComponent renderComponent='renderSsoGuideDialog' {...props} />;
+};
+
+export const ScimGuideDialog: FC<FronteggCMCComponentProps<ScimGuideDialogProps>> = (props) => {
+  return <CMCComponent renderComponent='renderScimGuideDialog' {...props} />;
 };

--- a/packages/react/src/cmc/cmc-components.tsx
+++ b/packages/react/src/cmc/cmc-components.tsx
@@ -1,4 +1,4 @@
-import { ChangePasswordFormProps, InviteUserDialogProps, ProfilePageProps, UsersTableProps } from '@frontegg/types';
+import { ChangePasswordFormProps, InviteUserDialogProps, ProfilePageProps, SsoGuideDialogProps, UsersTableProps } from '@frontegg/types';
 import React, { FC } from 'react';
 import { CMCComponent, FronteggCMCComponentProps, RenderableFronteggComponent } from './cmc-base';
 
@@ -16,4 +16,8 @@ export const ChangePasswordForm: FC<FronteggCMCComponentProps<ChangePasswordForm
 
 export const ProfilePage: FC<FronteggCMCComponentProps<ProfilePageProps>> = (props) => {
   return <CMCComponent renderComponent='renderProfilePage' {...props} />;
+};
+
+export const SsoGuideDialog: FC<FronteggCMCComponentProps<SsoGuideDialogProps>> = (props) => {
+  return <CMCComponent renderComponent='renderSsoGuideDialog' {...props} />;
 };

--- a/packages/react/src/cmc/cmc-components.tsx
+++ b/packages/react/src/cmc/cmc-components.tsx
@@ -1,4 +1,10 @@
-import { ChangePasswordFormProps, InviteUserDialogProps, ProfilePageProps, SsoGuideDialogProps, UsersTableProps } from '@frontegg/types';
+import {
+  ChangePasswordFormProps,
+  InviteUserDialogProps,
+  ProfilePageProps,
+  SsoGuideDialogProps,
+  UsersTableProps,
+} from '@frontegg/types';
 import React, { FC } from 'react';
 import { CMCComponent, FronteggCMCComponentProps, RenderableFronteggComponent } from './cmc-base';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,57 +2514,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.101.0":
-  version "7.101.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.101.0.tgz#9481ad8b24b808de6675657bdbb25e96087a2e7c"
-  integrity sha512-wkLmwhhtLNqaXA0IaJ4/beE+1wWZgdoj0NuDqA0wHKh2LRRs/0C9SWoPS4OcMJW3sGT+hxN+OquA3Snr69bpxw==
+"@frontegg/js@7.102.0-alpha.0":
+  version "7.102.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.102.0-alpha.0.tgz#38475e3410d03a86b53ede011c855061fdee5967"
+  integrity sha512-yQJ/pLfwFyQ6tdN7zxdjgp+Z2rL8MGF68t/QKhQQHAn91Cso5QcKR4LjIeoKVsGjcQEY7gC000Q7nmaD+cDs2w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.101.0"
+    "@frontegg/types" "7.102.0-alpha.0"
 
-"@frontegg/react-hooks@7.101.0":
-  version "7.101.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.101.0.tgz#cab4d0bb08e44ac6e525671283550727d7616e27"
-  integrity sha512-uiU+KBEXj24+exbT3n+h4ELIJY35cDQvqeKHwejjgSn7Zk7tz0EEr0mB2a1NSpi7U8/fto+hVgj3kMMRskHQhw==
+"@frontegg/react-hooks@7.102.0-alpha.0":
+  version "7.102.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.102.0-alpha.0.tgz#56a968b1f1f57d343836f7a68b3834cd46e666a0"
+  integrity sha512-Q0YzpCrlQafCQakIVSx1r9cY6TWbujj4JR3LBWn1H3myG+WgOFNdQaqfhiLn5upuXeXsuht2SHtCDEJBdo3tBw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.101.0"
-    "@frontegg/types" "7.101.0"
+    "@frontegg/redux-store" "7.102.0-alpha.0"
+    "@frontegg/types" "7.102.0-alpha.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.101.0":
-  version "7.101.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.101.0.tgz#e89d1f70c15ac5d26c5059fa3cb0d7848959bae4"
-  integrity sha512-AiqwUXl4oCV5KkDRornIwbGvviaFtmdmF9fAoBwtc+VKR1Iw9yZJSU59llubv5rTZmJR6L/98eDtqv0f/CawpA==
+"@frontegg/redux-store@7.102.0-alpha.0":
+  version "7.102.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.102.0-alpha.0.tgz#846f7c8446c065fdb423ee339d3406943049360b"
+  integrity sha512-xxiUATBQrKRx/EuSkfj27OyLBW1+3KYfsDSE+OxHNdaA7Qs7FrHWTbk0AwbaFXKF0NW3tm4pp5KXePFbRzO77g==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.101.0"
+    "@frontegg/rest-api" "7.102.0-alpha.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.101.0":
-  version "7.101.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.101.0.tgz#d0ffb550d08d0bab7b15aef1a0b637b787604619"
-  integrity sha512-zWWYFzf7cjw6xeeBKDqOyacgB9YDa6t/mpzh+pc/bb4aHz2e8rMzJAxhZkwJZUI/yU/dMsTe1loIEC84JgE5pw==
+"@frontegg/rest-api@7.102.0-alpha.0":
+  version "7.102.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.102.0-alpha.0.tgz#962c1b5812870aef7b625064df441f755e964cbc"
+  integrity sha512-56rSr/EODME1XrUeuRihB4wVGIIIy6d6tXzBR17bTrBF8ZT9UHuxb386ACRh7/U7yu1O31qG5AedhL82/uhHzg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.101.0":
-  version "7.101.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.101.0.tgz#254c9a3cb468a393066b5facfb7627922b318199"
-  integrity sha512-B1T1f50xvg4EUGRZtQPDBk3PpgZSdxGj5Fx3ltvVcD5Wxj1z+OTO3YFEM88dxM2PkNSMQzDneekruaVeEr+paA==
+"@frontegg/types@7.102.0-alpha.0":
+  version "7.102.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.102.0-alpha.0.tgz#9939613144af0983f30c572ef3b9f4be89f13515"
+  integrity sha512-ZpdK7Jz3L2apltDcHMuw//GUPG2shaU7zIMUFhXW/mML/lVQz9M4V/9GYRQWq2rb1Dm+cR6rg1livfnVydX/2w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.101.0"
+    "@frontegg/redux-store" "7.102.0-alpha.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,57 +2514,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.101.0-alpha.1":
-  version "7.101.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.101.0-alpha.1.tgz#6b1a526d0bf6851cf05ffe6e88c676e2f7508be4"
-  integrity sha512-xPmA5nFS8UmZbxi5z56OJQU6y9E98DToEs5ghz1y2zSl0tdWadpiEDUUhgRrvtS3NxNAjxIvEcbkp7l3Q3UlGw==
+"@frontegg/js@7.101.0-alpha.2":
+  version "7.101.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.101.0-alpha.2.tgz#1225b23fb5da7cebddfdf92243b143981a8ebcd4"
+  integrity sha512-WsnQUG57k8MIIWaJTssJZTLlac2B0X7wtyGTM1gfZ7hWae1rE3eQBJRBC3yFmEiCyN2lM0VeSX1v/csfVzU1uw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.101.0-alpha.1"
+    "@frontegg/types" "7.101.0-alpha.2"
 
-"@frontegg/react-hooks@7.101.0-alpha.1":
-  version "7.101.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.101.0-alpha.1.tgz#e9cd5aa6ef73b2292ded7b8bb92809b4a3c5f140"
-  integrity sha512-P8N1iZBTUi51W2NRGx6taDJJt73fyoN+HOdKc0ejTAUWTequDJ9VDk5EaEhHiO21/v166j5o5s2YA1cAiOdOKQ==
+"@frontegg/react-hooks@7.101.0-alpha.2":
+  version "7.101.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.101.0-alpha.2.tgz#8130aaf6169e8b4244f9be38cf4d4af613d510fe"
+  integrity sha512-vh2n2tdxfoD/irF9umxJEFDBl/PFF49Yklb1Kusc1pducnTOfTuPOOeJuwcnnSo9QeTMmlZEEE1FzV2wBbS7Eg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.101.0-alpha.1"
-    "@frontegg/types" "7.101.0-alpha.1"
+    "@frontegg/redux-store" "7.101.0-alpha.2"
+    "@frontegg/types" "7.101.0-alpha.2"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.101.0-alpha.1":
-  version "7.101.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.101.0-alpha.1.tgz#e047122fc091cda7890aca86994bc0ec4b22e1dc"
-  integrity sha512-0Z/W5o4jt63GLB3+nmCaJGq6gKI7K9BNbjs6c1kP8U9eqH5HPExkYn8u0pgXR4M0GnJ1Tjz33SZq1G2y2I/04Q==
+"@frontegg/redux-store@7.101.0-alpha.2":
+  version "7.101.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.101.0-alpha.2.tgz#4fa660647451dab72d57b0c5c40e54ec205df280"
+  integrity sha512-r9XJMWEkF941zmMHbHwEL8jlBJCaNbNe+TNnTkUaP/PEM+BOyGNM3LFI5Urfl6bbJd9bbrTphkBJ0JFJ/yxASA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.101.0-alpha.1"
+    "@frontegg/rest-api" "7.101.0-alpha.2"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.101.0-alpha.1":
-  version "7.101.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.101.0-alpha.1.tgz#a162a852920defe448ce79ccb78d78e6ea503730"
-  integrity sha512-5YD+MZ4YYv7av1BFXMfztlTjc+4JTxbtIYGfx2IjBhqykTjHkHjDb6W4tg/iicYkFlnK06vizSmcl0Hi1r0REg==
+"@frontegg/rest-api@7.101.0-alpha.2":
+  version "7.101.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.101.0-alpha.2.tgz#5a8ed48238953358cd43ef357a2878f2700711eb"
+  integrity sha512-E6UDRSP/zjox+4vuKlWqE0W3uZpOQjHbdCfc5/ujHs96naIst7WA2y9C1nSn1PvOhLPQb7ER/Ddh0IdSss+Fkw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.101.0-alpha.1":
-  version "7.101.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.101.0-alpha.1.tgz#0ad8cf179701bd2ed8980cbd7af8971c3aea9267"
-  integrity sha512-71q2xHXKp0O+O7xZB0uZ1AgfyIJJIVALG1N382977RnzskQwBYucB8Y/0D9oWpn1dEyAE6dSXz19jb91au/XSA==
+"@frontegg/types@7.101.0-alpha.2":
+  version "7.101.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.101.0-alpha.2.tgz#bc3b33f659b9126aa4ad43f08f678b14facf2cd2"
+  integrity sha512-Eqt3G297jGpGsAH8SzL6qtawXy/9zcZAfYaiu7SgvLyupIuYleyZ4X3m10h7P7UpcJzuc0Ps+GlUsXhgvzOzOg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.101.0-alpha.1"
+    "@frontegg/redux-store" "7.101.0-alpha.2"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,57 +2514,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.100.0-alpha.4":
-  version "7.100.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.100.0-alpha.4.tgz#2dea89d194a37d83ed13f45b7bc228ad749a4917"
-  integrity sha512-7TZ1SvdTUHFLaiuUhlEBSlC5ofU4r+rGWvKuqDbmGuOwdCDkKIN4NaHv1CeYDn+Hp1qn7EWJpecUmYPOcvMcrA==
+"@frontegg/js@7.101.0-alpha.1":
+  version "7.101.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.101.0-alpha.1.tgz#6b1a526d0bf6851cf05ffe6e88c676e2f7508be4"
+  integrity sha512-xPmA5nFS8UmZbxi5z56OJQU6y9E98DToEs5ghz1y2zSl0tdWadpiEDUUhgRrvtS3NxNAjxIvEcbkp7l3Q3UlGw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.100.0-alpha.4"
+    "@frontegg/types" "7.101.0-alpha.1"
 
-"@frontegg/react-hooks@7.100.0-alpha.4":
-  version "7.100.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.100.0-alpha.4.tgz#6a8e282e79c05c17e815be2769cdb5c327dab7d5"
-  integrity sha512-FupKVNSPfcpWpbrXft1DrWLSlYJr/ZshRQaQKDcARZkplkP0e3czNXAckriovAR8PWZQ6ae4x8t0GD0K2sGLFw==
+"@frontegg/react-hooks@7.101.0-alpha.1":
+  version "7.101.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.101.0-alpha.1.tgz#e9cd5aa6ef73b2292ded7b8bb92809b4a3c5f140"
+  integrity sha512-P8N1iZBTUi51W2NRGx6taDJJt73fyoN+HOdKc0ejTAUWTequDJ9VDk5EaEhHiO21/v166j5o5s2YA1cAiOdOKQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.100.0-alpha.4"
-    "@frontegg/types" "7.100.0-alpha.4"
+    "@frontegg/redux-store" "7.101.0-alpha.1"
+    "@frontegg/types" "7.101.0-alpha.1"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.100.0-alpha.4":
-  version "7.100.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.100.0-alpha.4.tgz#2594b42c461273c29576c55b7ee853821017f7b4"
-  integrity sha512-EN2r8ntBpymlViOnOM3QrHZjXjhWHGKfSvncJMJu2BNMTv6TzXMjE80U7cP88hktVW3n9cdvJN1UmJ2/SqZiHg==
+"@frontegg/redux-store@7.101.0-alpha.1":
+  version "7.101.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.101.0-alpha.1.tgz#e047122fc091cda7890aca86994bc0ec4b22e1dc"
+  integrity sha512-0Z/W5o4jt63GLB3+nmCaJGq6gKI7K9BNbjs6c1kP8U9eqH5HPExkYn8u0pgXR4M0GnJ1Tjz33SZq1G2y2I/04Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.100.0-alpha.4"
+    "@frontegg/rest-api" "7.101.0-alpha.1"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.100.0-alpha.4":
-  version "7.100.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.100.0-alpha.4.tgz#216a81fc9c42d26cd056dc4f7f33e8f1f9143d9f"
-  integrity sha512-4udhHBZrJfsZNarkx+UEyhvsToImtjd6MLz6M/z/NgHgxbmf+H4cFHpVjL0i3ORBUtmniaAu8hWZWlDA6qGAQg==
+"@frontegg/rest-api@7.101.0-alpha.1":
+  version "7.101.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.101.0-alpha.1.tgz#a162a852920defe448ce79ccb78d78e6ea503730"
+  integrity sha512-5YD+MZ4YYv7av1BFXMfztlTjc+4JTxbtIYGfx2IjBhqykTjHkHjDb6W4tg/iicYkFlnK06vizSmcl0Hi1r0REg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.100.0-alpha.4":
-  version "7.100.0-alpha.4"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.100.0-alpha.4.tgz#606323bd69cbfb841e71207b7d59a8263fd6d0bb"
-  integrity sha512-ZTQyfbctRvSRVMtkWekmNmFUrL8F2Ktrt9kggH0syvaRFYYvUk5k+VqoPSZ2fmZBH9bo0WQAzy98Nv9RJTdH0w==
+"@frontegg/types@7.101.0-alpha.1":
+  version "7.101.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.101.0-alpha.1.tgz#0ad8cf179701bd2ed8980cbd7af8971c3aea9267"
+  integrity sha512-71q2xHXKp0O+O7xZB0uZ1AgfyIJJIVALG1N382977RnzskQwBYucB8Y/0D9oWpn1dEyAE6dSXz19jb91au/XSA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.100.0-alpha.4"
+    "@frontegg/redux-store" "7.101.0-alpha.1"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,57 +2514,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.99.0":
-  version "7.99.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.99.0.tgz#686bc75ee1ed54f2e6ffe8e93c8c142664bf5a6f"
-  integrity sha512-LgbfKJo37k41B5flLFX3hkIm60wWBmHWoW78Z/eTlfl0SddnHxKh7zJ0GkAcMt+2MfGxsqZCXy2IpOzMNXnt6A==
+"@frontegg/js@7.100.0-alpha.4":
+  version "7.100.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.100.0-alpha.4.tgz#2dea89d194a37d83ed13f45b7bc228ad749a4917"
+  integrity sha512-7TZ1SvdTUHFLaiuUhlEBSlC5ofU4r+rGWvKuqDbmGuOwdCDkKIN4NaHv1CeYDn+Hp1qn7EWJpecUmYPOcvMcrA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.99.0"
+    "@frontegg/types" "7.100.0-alpha.4"
 
-"@frontegg/react-hooks@7.99.0":
-  version "7.99.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.99.0.tgz#5a3997be8b30729f9d1048d0e647c32101a2c2d0"
-  integrity sha512-NXRJT+dLe05VSNw2bscGLlxB9o7SE5UWA+HQQgBqxzWoecTqiW5i5s2m6QUI3OwY/dAYGPJMrDTIL+2SZaw66Q==
+"@frontegg/react-hooks@7.100.0-alpha.4":
+  version "7.100.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.100.0-alpha.4.tgz#6a8e282e79c05c17e815be2769cdb5c327dab7d5"
+  integrity sha512-FupKVNSPfcpWpbrXft1DrWLSlYJr/ZshRQaQKDcARZkplkP0e3czNXAckriovAR8PWZQ6ae4x8t0GD0K2sGLFw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.99.0"
-    "@frontegg/types" "7.99.0"
+    "@frontegg/redux-store" "7.100.0-alpha.4"
+    "@frontegg/types" "7.100.0-alpha.4"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.99.0":
-  version "7.99.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.99.0.tgz#fedb571081938497dd3e2d5bf600d9728e49c13d"
-  integrity sha512-01rXqfo364I6q1wip/EoPybs+DU1OIy5rgdKDcOQ25oC4Br+v0GUVyCTnEsvtSGOQZPLaH515EyIe1r7eupXKQ==
+"@frontegg/redux-store@7.100.0-alpha.4":
+  version "7.100.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.100.0-alpha.4.tgz#2594b42c461273c29576c55b7ee853821017f7b4"
+  integrity sha512-EN2r8ntBpymlViOnOM3QrHZjXjhWHGKfSvncJMJu2BNMTv6TzXMjE80U7cP88hktVW3n9cdvJN1UmJ2/SqZiHg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.99.0"
+    "@frontegg/rest-api" "7.100.0-alpha.4"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.99.0":
-  version "7.99.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.99.0.tgz#8c25c265e01ac4643c8b5831b9d0434a33b2826c"
-  integrity sha512-AEaBppndfjPNuAOJcC5QO83Q7CM5ywxCGAcpvjrOoU9fVmXI5SSdzqdIAMFXrjggXN+l937pCeCdfkXhckG37w==
+"@frontegg/rest-api@7.100.0-alpha.4":
+  version "7.100.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.100.0-alpha.4.tgz#216a81fc9c42d26cd056dc4f7f33e8f1f9143d9f"
+  integrity sha512-4udhHBZrJfsZNarkx+UEyhvsToImtjd6MLz6M/z/NgHgxbmf+H4cFHpVjL0i3ORBUtmniaAu8hWZWlDA6qGAQg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.99.0":
-  version "7.99.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.99.0.tgz#d0d2f90bb61eedaa4b38e9682a21de2b4a7217bd"
-  integrity sha512-bWPr8cnRJyhQ3EFDswrqEBs5z7EaRhvB7bepbjIycIP/84Jqef3IfPO8/fAPLJRnA2v0TqnlCmRMcXnLT6pi4Q==
+"@frontegg/types@7.100.0-alpha.4":
+  version "7.100.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.100.0-alpha.4.tgz#606323bd69cbfb841e71207b7d59a8263fd6d0bb"
+  integrity sha512-ZTQyfbctRvSRVMtkWekmNmFUrL8F2Ktrt9kggH0syvaRFYYvUk5k+VqoPSZ2fmZBH9bo0WQAzy98Nv9RJTdH0w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.99.0"
+    "@frontegg/redux-store" "7.100.0-alpha.4"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Upgrades core Frontegg dependencies to an alpha release and changes how CMC renders pass styling options, which could affect embedded admin components. The demo app also hardcodes staging `baseUrl`/`clientId`, which is easy to ship accidentally if not reverted.
> 
> **Overview**
> Adds new CMC wrappers `SsoGuideDialog` and `ScimGuideDialog` (backed by `renderSsoGuideDialog`/`renderScimGuideDialog`) and extends `CMCComponent` to accept/pass through `containerStyle` to the underlying `@frontegg/js` render call.
> 
> Updates the demo SaaS app with new pages and navigation/routes (`/cmc-sso`, `/cmc-scim`) showcasing these dialogs, and adds a CMC implementation guide markdown. Also bumps `@frontegg/js`/`@frontegg/react-hooks` dependencies to `7.102.0-alpha.0` and updates the demo app’s Frontegg `baseUrl`/`clientId` to hardcoded staging values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bffb8fbc8e8fcac9425dd3dbc1539ced45e0edb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->