### PR TITLE
fix - e2e trigger

### DIFF
--- a/.github/actions/trigger-e2e-test/action.yaml
+++ b/.github/actions/trigger-e2e-test/action.yaml
@@ -24,6 +24,8 @@ runs:
       with:
         app-id: ${{ inputs.bot_app_id }}
         private-key: ${{ inputs.bot_app_key }}
+        owner: frontegg
+        repositories: e2e-system-tests
     - name: "Trigger E2E tests"
       uses: actions/github-script@v7
       env:

--- a/.github/actions/trigger-e2e-test/action.yaml
+++ b/.github/actions/trigger-e2e-test/action.yaml
@@ -20,17 +20,17 @@ runs:
   steps:
     - id: create_bot_token
       name: Create bot token
-      uses: wow-actions/use-app-token@v2
+      uses: actions/create-github-app-token@v1
       with:
-        app_id: ${{ inputs.bot_app_id }}
-        private_key: ${{ inputs.bot_app_key }}
+        app-id: ${{ inputs.bot_app_id }}
+        private-key: ${{ inputs.bot_app_key }}
     - name: "Trigger E2E tests"
-      uses: actions/github-script@v5
+      uses: actions/github-script@v7
       env:
         version: ${{ inputs.version }}
         sha: ${{ inputs.sha }}
       with:
-        github-token: ${{ steps.create_bot_token.outputs.BOT_TOKEN }}
+        github-token: ${{ steps.create_bot_token.outputs.token }}
         script: |
           const {sha, version} = process.env;
           const repo = 'frontegg-react'


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches CI automation for dispatching E2E tests, including GitHub App token generation and `github-script` version/output changes, which could break the E2E trigger if misconfigured. No application runtime code is affected.
> 
> **Overview**
> Updates the composite `trigger-e2e-test` GitHub Action to generate its GitHub App token via `actions/create-github-app-token@v1` (scoped to `frontegg/e2e-system-tests`) instead of `wow-actions/use-app-token@v2`.
> 
> Bumps `actions/github-script` from `v5` to `v7` and switches the dispatch step to use the new token output (`steps.create_bot_token.outputs.token`) when triggering the E2E workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05f0bb82490f02f6dec3e29dccf96b4b55b171a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->