### PR TITLE
fix(ci): avoid shell injection in e2e trigger workflow

### DIFF
--- a/.github/workflows/trigger-e2e-test.yml
+++ b/.github/workflows/trigger-e2e-test.yml
@@ -18,9 +18,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Print inputs"
+        env:
+          VERSION: ${{ inputs.version }}
+          DISPATCH_ID: ${{ inputs.dispatch_id }}
         run: |
-          echo "Received test request for @frontegg/react@${{ inputs.version }}"
-          echo "From: ${{ inputs.dispatch_id }}"
+          echo "Received test request for @frontegg/react@${VERSION}"
+          echo "From: ${DISPATCH_ID}"
 
       - name: "Call trigger-e2e-test action"
         uses: ./.github/actions/trigger-e2e-test


### PR DESCRIPTION
## Summary
- Pass `workflow_dispatch` inputs (`version`, `dispatch_id`) through step `env` and reference them as shell variables in the print step, instead of interpolating `${{ inputs.* }}` directly into `run:`.
- Prevents untrusted input from being parsed as shell syntax (script injection).

## Test plan
- [ ] Confirm workflow still runs on manual `workflow_dispatch` with normal version/SHA inputs.
- [ ] Optional: trigger with a benign string containing shell metacharacters and confirm it is printed literally, not executed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small CI-only change that alters how `workflow_dispatch` inputs are echoed to the logs, reducing exposure to shell/script injection without changing the dispatched workflow call.
> 
> **Overview**
> Hardens the `trigger-e2e-test` GitHub Actions workflow by passing `workflow_dispatch` inputs (`version`, `dispatch_id`) through step `env` variables and referencing them in the shell script, instead of interpolating `${{ inputs.* }}` directly into `run:`.
> 
> This keeps untrusted input from being parsed as shell syntax while preserving the existing call to the local `trigger-e2e-test` action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a07f9fdedb489cda5ccf25c62076e871e031d862. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->