### PR TITLE
Update Frontegg AdminPortal to 7.112.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "7.111.0",
-    "@frontegg/react-hooks": "7.111.0"
+    "@frontegg/js": "7.112.0",
+    "@frontegg/react-hooks": "7.112.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,57 +2514,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.111.0":
-  version "7.111.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.111.0.tgz#ab06b82501a072751e0fd964c39d423fab8558c1"
-  integrity sha512-pDNJLykhVNwO9smFbWTjNKOtO2XOhLrTwYelC0Hah0cC/BNtZyogV8SoGOy5CP0ni1DFGBGJjjZNxRaZT8YwQw==
+"@frontegg/js@7.112.0":
+  version "7.112.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.112.0.tgz#183503ebbd89b334a37dcf65749d59941ef30120"
+  integrity sha512-RSKi5vg8fBePLl1bD7MrsKIt4QVHpUKl1p98Bf2lh9vZtCwK6ZNucnF/oeLio0HGUUY8ciCZJEJgX/RW7quwCw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.111.0"
+    "@frontegg/types" "7.112.0"
 
-"@frontegg/react-hooks@7.111.0":
-  version "7.111.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.111.0.tgz#d37c0badede0d726cb1d6f15d3882ca0f7b45bed"
-  integrity sha512-F4cbPGhqpH5KeFNMXuf9D1ChW/fSLPFEdIBv4Eu30GwVlI82MFb3yFHPMMXcK4QXYB5bn98VEGW4fuusKv8VKQ==
+"@frontegg/react-hooks@7.112.0":
+  version "7.112.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.112.0.tgz#f0be20c6f9c281952dc0bb8c08405ec057b2a781"
+  integrity sha512-Pu0NMByLBv4+bY0IwR9QFd6q87OW8moFo6VbHRWzzM1ISM3XUyxCj9nd8nvq7ffwMpKO/uyZL0rQYFXsKp/Fxg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.111.0"
-    "@frontegg/types" "7.111.0"
+    "@frontegg/redux-store" "7.112.0"
+    "@frontegg/types" "7.112.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.111.0":
-  version "7.111.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.111.0.tgz#eb1acc6941ab94abd99802ba021a793185daa38b"
-  integrity sha512-OEdiong8II+CVfBDfObecO5G2Qb6rEOCnsKULHdFS4tOKrVTPo7EkQn1zE6xZMbaYolugzfpD8wbv1Kk7dnu9A==
+"@frontegg/redux-store@7.112.0":
+  version "7.112.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.112.0.tgz#623992069735a4fee82ba916a29a2731f8ba529f"
+  integrity sha512-FV9UDVHac6GCiBygdGRScsdEqftXMaLxKlJiBswGAhHBGlnCdC7G/8kK/6BmCYEUYbU4t5XbAc+rUyBarsPnDA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.111.0"
+    "@frontegg/rest-api" "7.112.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.111.0":
-  version "7.111.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.111.0.tgz#fdc645698b5f6c9844d0eec44d82cba95d19a22e"
-  integrity sha512-iHoDj+bvfdeUl62HM3q92wrFjyemopVhgykxPu//KTfCJJf+eZAdFuoLV4DOKnT7VRKa0oj5pDMACnB3UuuDfA==
+"@frontegg/rest-api@7.112.0":
+  version "7.112.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.112.0.tgz#dbb305895a0e9d6c23208667413c2888b48fcd93"
+  integrity sha512-0xC/oRUde3bbMl0zmTKn/3+hZHAtWm48aglybN2FiUd0I7XeIvzZYsQLCKs5xPWz79kxc5VhIWY8JB9sEMLFvw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.111.0":
-  version "7.111.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.111.0.tgz#fc1d0715db85e7bf42c0ccad34f738a51f509717"
-  integrity sha512-06iGx5uNKEtVwHwkaI0LU8WASbYI1wvhl7dLv49WXSDAYM/CQCpzkUr9sIPJFZt/d93pL3Max/KGjUkynwEMNQ==
+"@frontegg/types@7.112.0":
+  version "7.112.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.112.0.tgz#8e20e68077eec17a39fd23e46c8b162af33de1ed"
+  integrity sha512-Uhl+Pu0iUutHFG5hCWxeN6vqoll8abxNsFFWh14BExZ0aI50AMAbc6VsxpMDDKRXevxvqlSiVfUuVAgtn1XGyw==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.111.0"
+    "@frontegg/redux-store" "7.112.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-24579 - Fixed admin-portal redirect race on native auth handoff
- FR-24579 - Fixed admin-portal mobile bridge capability gating and stuck loading

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile and dependency version pins only; no application code changes in this repository.
> 
> **Overview**
> Bumps **`@frontegg/react`**’s direct dependencies from **7.111.0** to **7.112.0**: `@frontegg/js` and `@frontegg/react-hooks`, with **`yarn.lock`** updated for the full `@frontegg/*` tree (`types`, `redux-store`, `rest-api`, etc.).
> 
> This release line includes Admin Portal fixes referenced in **FR-24579** (redirect race on native auth handoff, mobile bridge capability gating / stuck loading); those changes live in the published packages, not in this repo’s source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e008404ff704c75ca374a83fe38b756b680c773d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->