### PR TITLE
Update Frontegg AdminPortal to 7.114.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "7.113.0",
-    "@frontegg/react-hooks": "7.113.0"
+    "@frontegg/js": "7.114.0",
+    "@frontegg/react-hooks": "7.114.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,57 +2514,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.113.0":
-  version "7.113.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.113.0.tgz#204a18d336b69e9f1efc31c08511d51a0cc2b064"
-  integrity sha512-u+JW4WDDk6Kv8b3B+rjDy/XMawYQ7dIjCn/Xr+BeM1oiNoFQnLjC+iBNG+BpJPAO60Sahb/ilrUkd1bO36jSDw==
+"@frontegg/js@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.114.0.tgz#8f6bab2c7542f6ff2d806877096807cd3e818865"
+  integrity sha512-eX5bQbOe+Kj9/nWBCi+zfnqdtembPWmESdcnfixzvnbLRe4IdcI3CQO1FKwWd9G+U5Vs7T2gVimAvrM2PuZwkQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.113.0"
+    "@frontegg/types" "7.114.0"
 
-"@frontegg/react-hooks@7.113.0":
-  version "7.113.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.113.0.tgz#af9b68b86d3639e3f06ebd096bbfa8a12418f4a6"
-  integrity sha512-b3CB0Q3KQjzQwhKabm66ip6cuWDopOIWmtl9eU1nGYR74u550rw+bzqiZNOu9bC9O1kPqutKvzdItqjBmwoNjA==
+"@frontegg/react-hooks@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.114.0.tgz#e5bf040858e4f0540f039f8189045d5091ad210f"
+  integrity sha512-JeT9MWHYxQPaSZKn+nJqAXyQlIosYRP3uaySHWBvDW1YCvVJUpwjv6KjRt/xW07BEn0oRUx1EM1+mCr3dM2xTQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.113.0"
-    "@frontegg/types" "7.113.0"
+    "@frontegg/redux-store" "7.114.0"
+    "@frontegg/types" "7.114.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.113.0":
-  version "7.113.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.113.0.tgz#5f8587eaa35cf8f075e8f3bd60e107dae2bb0edb"
-  integrity sha512-NjmzBwK9T7OtI6rF1ZOlwuFwttHUb5QxCZaPq23McEtV7wNiIbMvWQpstnK0/WEV2odjWjYLrJO0n9PK4bpDcg==
+"@frontegg/redux-store@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.114.0.tgz#8c3316527736419ab0d0096ce86236f6293f715c"
+  integrity sha512-VZ0rtw1Qz6Fe5ZjTndRCoy1RLKcu7OYl6AJ0OJFoItBedXxbgk1Wtx3v+3q+fYo6t57xJMAMhEJJdn3fgjYvWg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.113.0"
+    "@frontegg/rest-api" "7.114.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.113.0":
-  version "7.113.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.113.0.tgz#f363cff59444cf2ad3022a0e2c051677e9037f43"
-  integrity sha512-3F1aerS8NUhiSyMoadcAz5NGY3W1dZNLuWFUYrlpHlUcMsrHHHAq8vuMsTZoKzxOGXuWH02zmEGqoLBijfOWIQ==
+"@frontegg/rest-api@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.114.0.tgz#b7fea8f367fb3b768f230d2dac8aab2e22faf5c9"
+  integrity sha512-3HlLyPaj1XG9rySafW+q2/Q5XOinxuJn8Qsrk93IFZgC6pTn3rNEi0Pftv7ihStOYS1D9LesgVj43NnOWXAP3Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.113.0":
-  version "7.113.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.113.0.tgz#f5185721d7b301eef8d9a894b31b79344e497851"
-  integrity sha512-Mqp/nS4rM1WP5tg7cV355ajsMB7NMHe9kgrJHUZUf/MIye6IGhjLWx0zV/POfnS4/bJ82P4mxHIxlVEgnTiaKw==
+"@frontegg/types@7.114.0":
+  version "7.114.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.114.0.tgz#021f3a746549b47f28c5e33272b9a7416c472e6d"
+  integrity sha512-4JSJOQoWcWpCJAkRlw0eLuy0qi0LiwRu2KF687Y8NjO78S+D6K4ldwcnueo0EK4+kR723oT42TVKpQzC8Hz+MQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.113.0"
+    "@frontegg/redux-store" "7.114.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-24988 - Fixed hosted login box accessibility issues
- FR-25494 - fixed stale frontegg oauth stale

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only version bump with no local code changes; risk is limited to behavior changes inside the 7.114.0 SDK packages.
> 
> **Overview**
> Updates **`@frontegg/react`** to consume **Frontegg SDK 7.114.0** by bumping **`@frontegg/js`** and **`@frontegg/react-hooks`** from `7.113.0` to `7.114.0`, with matching lockfile entries for the transitive **`@frontegg/types`**, **`@frontegg/redux-store`**, and **`@frontegg/rest-api`** packages.
> 
> No application source in this repo changes; consumers get upstream fixes from that release (per PR notes: hosted login box accessibility and Frontegg OAuth stale-session handling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fa66ce0d59280ce82830e924242df4039f5882c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->