### PR TITLE
ci: use GitHub App token for cross-repo dispatch instead of expiring PAT

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -105,12 +105,22 @@ jobs:
             const checkingVersion = '${{ steps.set_current_version.outputs.CURRENT_VERSION }}';
             const checkNpmVersions = require('./scripts/wait-for-npm-indexing.js');
             await checkNpmVersions(github, ['@frontegg/react'], checkingVersion);
+      - name : "Create bot token for dispatch"
+        id : dispatch_bot_token
+        uses : actions/create-github-app-token@v1
+        with :
+          app-id : ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
+          private-key : ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
+          owner : frontegg
+          repositories : |
+            oauth-service
+            dashboard
       - name : "Trigger Oauth and Dashboard Services Pipeline Workflow"
         uses : actions/github-script@v5
         env :
           PR_VERSION : '${{ steps.set_current_version.outputs.CURRENT_VERSION }}'
         with :
-          github-token : ${{ secrets.DISPATCH_WORKFLOWS_TOKEN }}
+          github-token : ${{ steps.dispatch_bot_token.outputs.token }}
           script : |
             const fe_react_version = process.env.PR_VERSION;
             const owner = 'frontegg';


### PR DESCRIPTION
Replace secrets.DISPATCH_WORKFLOWS_TOKEN (an expiring PAT) with a short-lived GitHub App token minted at runtime via actions/create-github-app-token, scoped to oauth-service and dashboard.

Reuses the GH_FRONTEGG_BOT_APP_ID / GH_FRONTEGG_BOT_APP_SECRET pattern already used by the e2e trigger action in this repo. App tokens do not expire, so this removes the recurring token-expiry breakage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only credential swap for workflow dispatch; no runtime app or package behavior changes, assuming the bot app has dispatch permissions on the target repos.
> 
> **Overview**
> After NPM publish, the **publish** workflow still dispatches `update-react-dependency` workflows in **oauth-service** and **dashboard**, but authentication for those calls no longer uses `secrets.DISPATCH_WORKFLOWS_TOKEN`.
> 
> A new **Create bot token for dispatch** step mints a short-lived token via `actions/create-github-app-token@v1`, using `GH_FRONTEGG_BOT_APP_ID` / `GH_FRONTEGG_BOT_APP_SECRET` and limiting access to those two repos—the same bot pattern already used for e2e triggers. The downstream `github-script` step now passes `steps.dispatch_bot_token.outputs.token` as `github-token` instead of the PAT.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcfa98100cb78f82301d252f4ddc21a6e73afd28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->