### PR TITLE
ci: upgrade create-github-app-token action to v3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -107,7 +107,7 @@ jobs:
             await checkNpmVersions(github, ['@frontegg/react'], checkingVersion);
       - name : "Create bot token for dispatch"
         id : dispatch_bot_token
-        uses : actions/create-github-app-token@v1
+        uses : actions/create-github-app-token@v3
         with :
           app-id : ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
           private-key : ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,7 +109,7 @@ jobs:
         id : dispatch_bot_token
         uses : actions/create-github-app-token@v3
         with :
-          app-id : ${{ secrets.GH_FRONTEGG_BOT_APP_ID }}
+          client-id : ${{ secrets.GH_FRONTEGG_BOT_CLIENT_ID }}
           private-key : ${{ secrets.GH_FRONTEGG_BOT_APP_SECRET }}
           owner : frontegg
           repositories : |


### PR DESCRIPTION
## Summary
- Upgrade `actions/create-github-app-token` from `@v1` to `@v3` in `publish.yml`, since v1 is being deprecated soon.

## Test plan
- [ ] Verify the publish workflow runs successfully and the bot token is created for cross-repo dispatch.

Made with [Cursor](https://cursor.com)