### PR TITLE
Update Frontegg AdminPortal to 7.119.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "7.118.0",
-    "@frontegg/react-hooks": "7.118.0"
+    "@frontegg/js": "7.119.0",
+    "@frontegg/react-hooks": "7.119.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,57 +2514,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.118.0":
-  version "7.118.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.118.0.tgz#96120eb736bf1b16b851a7d02116b1e1adcc45c2"
-  integrity sha512-IPQ+68ZkcBGtND61W/6Y5tkqawWKFWYYDHZq7+OV00dyBvUO4xxo25MnLRExmdKHqPCANDi+3NtDx062AglSGA==
+"@frontegg/js@7.119.0":
+  version "7.119.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.119.0.tgz#6b9df0f41390a9b2ac8ef3dbedc3d46fae8a3b80"
+  integrity sha512-U4A0Gz57G/trMHZpOf8tG94LLbsc0A+DbZmBJ4eMQFM+zS/4UKgc3k0V0QdeID3D4nPr8T+RuqqueOOHVlFBdg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.118.0"
+    "@frontegg/types" "7.119.0"
 
-"@frontegg/react-hooks@7.118.0":
-  version "7.118.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.118.0.tgz#e5a20efdf2cfbcfb4400fbe6231fa52de7989184"
-  integrity sha512-tA+S5/MiEWOpYWG8/jzORmq1a9dqX79rzYgXoV3pfy24+seP+QpCwkKhHSdBd5SFvEC799v+Db3xxwKFZ9b4aQ==
+"@frontegg/react-hooks@7.119.0":
+  version "7.119.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.119.0.tgz#ac3f5433cdeeaeabbfe912e24c1433b946d4671f"
+  integrity sha512-ji1jzk7muyLoVH/l9brdqXpNa5FUGVEojHVfM1kQ/VYYvt2zKviUpmYdyXZAWxsheCTEF2sumpJMTGhhxAROWQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.118.0"
-    "@frontegg/types" "7.118.0"
+    "@frontegg/redux-store" "7.119.0"
+    "@frontegg/types" "7.119.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.118.0":
-  version "7.118.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.118.0.tgz#394f7d7765060fb8bb4be60abd4ce79a75c32a6a"
-  integrity sha512-XrET52gdXo65b3qf3UozXPvjawgoDjZZ6HD36so2ximlPpyRBwHG3h2iRtjNML/QdaCbTH8NnGYVuinwKPA+0A==
+"@frontegg/redux-store@7.119.0":
+  version "7.119.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.119.0.tgz#e932dab1cc046242ac70d81d5afe64f863aba045"
+  integrity sha512-TKdkfdqiV6x7IjmwNfhUEpmCYLuLLshR1bTdZdIaEMr+4PjTKnN+qIEX8Gb/Dy9eVJCHIC4/pFegQBK+s655Gg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.118.0"
+    "@frontegg/rest-api" "7.119.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.118.0":
-  version "7.118.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.118.0.tgz#c1fbf6cb76ba3033942afa8d63879ee237954433"
-  integrity sha512-kjVZKV5yRZQPwua2Xw+HYxmPIg/NujNYPCo325oiGBffxVWvlDyaIVAofjtVfohHaQlEpcluOcBD7juc6m7xIg==
+"@frontegg/rest-api@7.119.0":
+  version "7.119.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.119.0.tgz#2ab4e1a769ac9b1c08f25d09396140ac903a2a3d"
+  integrity sha512-Tm2fmbRGNHWJT4SAr0cKdOWxgqFPMx9RsMxpgNtkDiFEdAUrusoDYKogJsm9YVQcXFuJnYuBTNfpCClPXDx5jg==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.118.0":
-  version "7.118.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.118.0.tgz#0fbeb6bcf1e9494c3e99bd454eef716e5d98d2f8"
-  integrity sha512-atiJTJaoD3wiCYpeByyGyy72uL8l2rKoQmBI1q1g4JOETzQLpZPj05mbKlLHmoPJMhL0XYd1u3jhMIopWI1H+w==
+"@frontegg/types@7.119.0":
+  version "7.119.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.119.0.tgz#ec62cf7e13687ff25cab848f6c489ab0bd7fd863"
+  integrity sha512-hye2AFyd+X2svUNCYBc1WjnrnwXyQOtMfxOJpApEKlTy9uwrD0u1DcNxQE0iEzf3tYFosqeD46FOzsmhZeHeeg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.118.0"
+    "@frontegg/redux-store" "7.119.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-26014 - Added admin-box addressType redux branch (external instant-nav) [7.119.x]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version pin and lockfile-only change; risk is limited to regressions or behavior changes in the upstream 7.119.0 Admin Portal packages.
> 
> **Overview**
> Bumps **`@frontegg/react`**’s pinned Frontegg Admin Portal stack from **7.118.0** to **7.119.0** by updating `@frontegg/js` and `@frontegg/react-hooks` in `packages/react/package.json` and refreshing **`yarn.lock`** for the related `@frontegg/*` packages (`redux-store`, `rest-api`, `types`).
> 
> There is no application source change in this repo; consumers of `@frontegg/react` pick up upstream **7.119.x** behavior, including **FR-26014** (admin-box **`addressType`** redux branch for external instant navigation) as noted in the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06addbf5b454469eb22259736809182a9f054299. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->