### PR TITLE
Update Frontegg AdminPortal to 7.124.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "7.123.0",
-    "@frontegg/react-hooks": "7.123.0"
+    "@frontegg/js": "7.124.0",
+    "@frontegg/react-hooks": "7.124.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,57 +2514,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.123.0":
-  version "7.123.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.123.0.tgz#0bb5e22c61c8e9e9a9cce00bb7a347b686918aba"
-  integrity sha512-rqAeAzuNOs6qmnMIH6K6Gr+mVcaXL7u9/gH38VSsZWB6L1K43KbV53uBa4ID9PGaVNrbRW5feCrh9X2yuL61uA==
+"@frontegg/js@7.124.0":
+  version "7.124.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.124.0.tgz#5e37f39992ced3870c68fb68ef9af0cf724d9f7e"
+  integrity sha512-yElZI7Wb9lOyQKwDVo4U+3jUv8e3oFOgbf6vCQP4m80tjfmQy7sDB+PKRd7M6blnaibugcXh16thJ3cHoxTliA==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.123.0"
+    "@frontegg/types" "7.124.0"
 
-"@frontegg/react-hooks@7.123.0":
-  version "7.123.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.123.0.tgz#781f2c68340831d36801fb1dfd01866b88d2d310"
-  integrity sha512-1tIbewmBkSnX7YY34/FgDuHwAjs/uX838VOyK4SjnM3Jft8xw5OhOTtpT3KB33lSpFHRJRlaRdiQOFn0eEmNMg==
+"@frontegg/react-hooks@7.124.0":
+  version "7.124.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.124.0.tgz#a86e8e37ba1bd7a67525e41b94e4d29a875230df"
+  integrity sha512-tR871KYBbrNbjOfz5iRj70km8zfZCCN0swMtYE7TPEcJbyjNDZtrZ72xHHNGmJH4umUx4PCL6iJqYxTrLzOSEg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.123.0"
-    "@frontegg/types" "7.123.0"
+    "@frontegg/redux-store" "7.124.0"
+    "@frontegg/types" "7.124.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.123.0":
-  version "7.123.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.123.0.tgz#de9c8d97b471856e34cf081b557ceec3e9f1a3e9"
-  integrity sha512-h98FS39uf3vdz+nmzt6mD2wIhr4Bcer7iaZbU/nDUBeC2uWaCd8VATf9zQZ/eWoMzssen1NC0gIVMIs50rK7KQ==
+"@frontegg/redux-store@7.124.0":
+  version "7.124.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.124.0.tgz#8cc4038b3a309b8cc8e6b4da2bd1b47a4ceb03f0"
+  integrity sha512-SKMSYjBL3tIAN7NvmRPQBc598jz31YcOlQwtDd3FZkob02vyLFhOJTSS2MG/YaXIEDlAFYAWy9QxdqgjrPU9eA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.123.0"
+    "@frontegg/rest-api" "7.124.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.123.0":
-  version "7.123.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.123.0.tgz#afdde5c6d8f2da8c54e10456a4eda4473fa61dad"
-  integrity sha512-Rznqx68yxlFo1iGvDy/MkyvANZRUKDTw6Fg9mbl3ajtcVMEE37of6BLIYlGaaKzasp9Y5rxdky0mOi0tuyQGFQ==
+"@frontegg/rest-api@7.124.0":
+  version "7.124.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.124.0.tgz#719381739ec2db90a44a6255044663681a9c0e24"
+  integrity sha512-WOIhh9WWNfSqsRkJN7WC+WMYe3DOu0y20XGrIhI3AKFgep50mWiD1DW7BwPWrAZhlJPEkrHCpkMIE2CNLacg1Q==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.123.0":
-  version "7.123.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.123.0.tgz#4c3e5532061a0f0e285eb01c0960a675d203d81d"
-  integrity sha512-Q52NCG9c9A43nXj1CfMB4xAKfmJlMKfkZBu4H38dzefaAi/nl3Sw4Q3qu5582lfi5pv4yqMcGzy4v0hELUo2YQ==
+"@frontegg/types@7.124.0":
+  version "7.124.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.124.0.tgz#b18e466cc3ea3675fd07e61fa1ca3686c61ff6eb"
+  integrity sha512-PDEhoTf26eoUAxlCSaieY6VSaY+/ieg9E09pbrCoG4FIg4EAQ2MYGHc8EhWWcLQhmCL9WGhI7Sci7AlFEp+h/w==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.123.0"
+    "@frontegg/redux-store" "7.124.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-26036 - Fixed tenant selection takes precedence over skipUserLoading

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change, but it alters auth/session loading behavior in upstream packages (tenant vs. skipUserLoading), which can affect multi-tenant login flows.
> 
> **Overview**
> **Bumps** `@frontegg/react`’s direct dependencies from **7.123.0** to **7.124.0** (`@frontegg/js`, `@frontegg/react-hooks`) and refreshes **`yarn.lock`** so the aligned **7.124.0** tree is pinned (`types`, `redux-store`, `rest-api`, etc.).
> 
> Consumers of this package pick up upstream **Admin Portal / SDK** behavior from that release, including the fix where **tenant selection takes precedence over `skipUserLoading`** (FR-26036). No application source in this repo changes beyond the version pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78b7c25ebb99a2e7cd06f52ff9e5d297f077318f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->