### PR TITLE
Update Frontegg AdminPortal to 7.125.0

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,8 +19,8 @@
     "build:watch": "rm -rf dist && mkdir dist && rollup -w -c ./rollup.config.js"
   },
   "dependencies": {
-    "@frontegg/js": "7.124.0",
-    "@frontegg/react-hooks": "7.124.0"
+    "@frontegg/js": "7.125.0",
+    "@frontegg/react-hooks": "7.125.0"
   },
   "peerDependencies": {
     "react": ">16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2514,57 +2514,57 @@
   resolved "https://registry.yarnpkg.com/@frontegg/entitlements-javascript-commons/-/entitlements-javascript-commons-1.1.2.tgz#8c771cac0796fde5bbc05abe750cb6b8677ec2c6"
   integrity sha512-vwCFxj9KSIKHXinOH0HbBf4DhKRbUWhjCnL14+JfQnwuEl/zKtSGZoZecrXcPajWUypdi0uT+8q3GGcqnCW13Q==
 
-"@frontegg/js@7.124.0":
-  version "7.124.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.124.0.tgz#5e37f39992ced3870c68fb68ef9af0cf724d9f7e"
-  integrity sha512-yElZI7Wb9lOyQKwDVo4U+3jUv8e3oFOgbf6vCQP4m80tjfmQy7sDB+PKRd7M6blnaibugcXh16thJ3cHoxTliA==
+"@frontegg/js@7.125.0":
+  version "7.125.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/js/-/js-7.125.0.tgz#3431d7cfa401392f9cacbdea25ed80c8ac24c855"
+  integrity sha512-lScju2nXgElF4nPc7fiM5dtJMBvfaCybj/D6bTTnMe7N7NFT0LUM6qQv45/xsV42uHSdzBpN/T/hT9baY01RXQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/types" "7.124.0"
+    "@frontegg/types" "7.125.0"
 
-"@frontegg/react-hooks@7.124.0":
-  version "7.124.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.124.0.tgz#a86e8e37ba1bd7a67525e41b94e4d29a875230df"
-  integrity sha512-tR871KYBbrNbjOfz5iRj70km8zfZCCN0swMtYE7TPEcJbyjNDZtrZ72xHHNGmJH4umUx4PCL6iJqYxTrLzOSEg==
+"@frontegg/react-hooks@7.125.0":
+  version "7.125.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/react-hooks/-/react-hooks-7.125.0.tgz#260f3e39e38d56196ab4785dca7163e7432f0c09"
+  integrity sha512-6glWs/SQcNGdG0tHA2WEOMbcRZHUpe/amwHtXKmBsMnpVQr8KEo5tlUBNri5zDY5r9VP48BZXe529wUQ89oVQg==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.124.0"
-    "@frontegg/types" "7.124.0"
+    "@frontegg/redux-store" "7.125.0"
+    "@frontegg/types" "7.125.0"
     "@types/react" "*"
     "@types/react-is" "^17.0.7"
     get-value "^3.0.1"
     react-is "^17.0.2"
     use-sync-external-store "^1.2.2"
 
-"@frontegg/redux-store@7.124.0":
-  version "7.124.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.124.0.tgz#8cc4038b3a309b8cc8e6b4da2bd1b47a4ceb03f0"
-  integrity sha512-SKMSYjBL3tIAN7NvmRPQBc598jz31YcOlQwtDd3FZkob02vyLFhOJTSS2MG/YaXIEDlAFYAWy9QxdqgjrPU9eA==
+"@frontegg/redux-store@7.125.0":
+  version "7.125.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/redux-store/-/redux-store-7.125.0.tgz#3c1b86eee405d016aceb4bbe36a89ac22d2485bd"
+  integrity sha512-fBrMM9YU7tU1+NvHPyehtnyFT/epYpTWznn0Vt/Baus4fjE0DqsbOe0AU+88swouPrMQAx24sAwkuTmbYALQCw==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
-    "@frontegg/rest-api" "7.124.0"
+    "@frontegg/rest-api" "7.125.0"
     fast-deep-equal "3.1.3"
     get-value "^3.0.1"
     proxy-compare "^3.0.0"
     set-value "^4.1.0"
     uuid "^10.0.0"
 
-"@frontegg/rest-api@7.124.0":
-  version "7.124.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.124.0.tgz#719381739ec2db90a44a6255044663681a9c0e24"
-  integrity sha512-WOIhh9WWNfSqsRkJN7WC+WMYe3DOu0y20XGrIhI3AKFgep50mWiD1DW7BwPWrAZhlJPEkrHCpkMIE2CNLacg1Q==
+"@frontegg/rest-api@7.125.0":
+  version "7.125.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/rest-api/-/rest-api-7.125.0.tgz#f278900ee68878b93b53436317e0d1455ddbe4dc"
+  integrity sha512-t7wZZbB/6+IJ8d7OZpUboyENaiQhzxCZ46VKTxkDtlvgCgSh5EQAQxPMZ1fNIay9dxq9tNyTodP90zjt+FKXUA==
   dependencies:
     "@babel/runtime" "^7.18.6"
     "@frontegg/entitlements-javascript-commons" "1.1.2"
 
-"@frontegg/types@7.124.0":
-  version "7.124.0"
-  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.124.0.tgz#b18e466cc3ea3675fd07e61fa1ca3686c61ff6eb"
-  integrity sha512-PDEhoTf26eoUAxlCSaieY6VSaY+/ieg9E09pbrCoG4FIg4EAQ2MYGHc8EhWWcLQhmCL9WGhI7Sci7AlFEp+h/w==
+"@frontegg/types@7.125.0":
+  version "7.125.0"
+  resolved "https://registry.yarnpkg.com/@frontegg/types/-/types-7.125.0.tgz#93407d723ec043815603acb83f6dd40d05c67c07"
+  integrity sha512-41EAkj4pcTcPsG7jnllPsnBhLo9XUnJL6aX1ghJ/koCFqRywAioV8TMQyg5b/msNfeE3fPkMYjp18TNLvM8WlQ==
   dependencies:
     "@babel/runtime" "^7.18.6"
-    "@frontegg/redux-store" "7.124.0"
+    "@frontegg/redux-store" "7.125.0"
     csstype "^3.0.9"
     deepmerge "^4.2.2"
 


### PR DESCRIPTION
- FR-26860 - Fixed lastTermsCheck missing on signup when terms are text-only
- FR-25906 - Fixed the passkey button reading as disabled after a cancelled credential sheet
- FR-26334 - Fixed the MFA method-selection page painting without layout on iOS
- FR-23613 - Changed role pickers to restrict equal-level assignment
- FR-26112 - Fixed email keyboard and passkey autofill on the login identifier

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump with no in-repo code changes; behavior changes are limited to the upstream 7.125.0 release.
> 
> **Overview**
> Bumps `@frontegg/react`’s pinned `@frontegg/js` and `@frontegg/react-hooks` from **7.124.0** to **7.125.0**, with `yarn.lock` updated for the full 7.125.0 stack (`types`, `redux-store`, `rest-api`). No local source changes—consumers pick up the AdminPortal **7.125.0** fixes via the new packages.
> 
> That release includes signup terms handling when terms are text-only (`lastTermsCheck`), passkey UI after a cancelled credential sheet, MFA method-selection layout on iOS, stricter equal-level role assignment in role pickers, and login identifier email keyboard / passkey autofill behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd93a9be3013745a8d66729ad2caa66d47e61fa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->